### PR TITLE
fix STDIN audio rates

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -96,7 +96,7 @@ typedef struct
   PaStream* audio_in_pa_stream;
 #endif
   uint32_t rtlsdr_center_freq;
-  int rtlsdr_ppm_error;
+  int rtlsdr_ppm_error; //was int, changed to float
   int audio_in_type; // 0 for device, 1 for file, 2 for portaudio, 3 for rtlsdr
   char audio_out_dev[1024];
   int audio_out_fd;


### PR DESCRIPTION
fix STDIN audio rates
made a boo boo with pulse audio rates tinkering, had to fix rates for STDIN so that decoded audio played out at the correct rate