### PR TITLE
DMR Stereo Audio and Timing Tweaks

### DIFF
--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -420,7 +420,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
     if (internalslot == 1 && vc2 == 6)
     {
       state->dropR = 256;
-      if (state->payload_algidR != 0 && opts->payload == 1) //&& opts->payload == 1
+      if (state->payload_algidR != 0 ) //&& opts->payload == 1
       {
         LFSR(state);
         fprintf (stderr, "\n");

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -329,7 +329,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         {
           //LFSR(state); //placement here causes issues when second slot becomes active as well
         }
-        //fprintf (stderr, "\n");
+        fprintf (stderr, "\n");
       }
       else
       {
@@ -345,7 +345,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         {
           //LFSR(state); //placement here causes issues when second slot becomes active as well
         }
-        //fprintf (stderr, "\n");
+        fprintf (stderr, "\n");
       }
     }
 
@@ -366,7 +366,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         {
           //LFSR(state);
         }
-        //fprintf (stderr, "\n");
+        fprintf (stderr, "\n");
       }
       else
       {
@@ -382,7 +382,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         {
           //LFSR(state);
         }
-        //fprintf (stderr, "\n");
+        fprintf (stderr, "\n");
       }
     }
     if (internalslot == 0 && vc1 == 6) //presumably when full (and no sync issues)
@@ -399,73 +399,6 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       fprintf (stderr, "\n");
     }
 
-    //test printing ambe_fr values
-    /*
-    if (1 == 1)
-    {
-      fprintf (stderr, "\nAMBE_FR1 = ");
-      for (j = 0; j < 4; j++)
-      {
-        fprintf (stderr, " - ");
-        for (k = 0; k < 12;)
-        {
-          int b = 0;
-          int c = 0;
-          int d = 0;
-          int e = 0;
-          b = ambe_fr[j][k];
-          c = ambe_fr[j][k+1];
-          d = ambe_fr[j][k+2];
-          e = ambe_fr[j][k+3];
-          //fprintf (stderr, "%X", (((uint8_t)ambe_fr[k] << 2) + ambe_fr[k+1]) );
-          fprintf (stderr, "%01X", ( (b << 3) + (c << 2) + (d << 1) + e ) );
-          k = k + 4;
-        }
-      }
-      fprintf (stderr, "\nAMBE_FR2 = ");
-      for (j = 0; j < 4; j++)
-      {
-        fprintf (stderr, " - ");
-        for (k = 0; k < 12;)
-        {
-          int b = 0;
-          int c = 0;
-          int d = 0;
-          int e = 0;
-          b = ambe_fr2[j][k];
-          c = ambe_fr2[j][k+1];
-          d = ambe_fr2[j][k+2];
-          e = ambe_fr2[j][k+3];
-          //fprintf (stderr, "%X", (((uint8_t)ambe_fr[k] << 2) + ambe_fr[k+1]) );
-          fprintf (stderr, "%01X", ( (b << 3) + (c << 2) + (d << 1) + e ) );
-          k = k + 4;
-        }
-      }
-      fprintf (stderr, "\nAMBE_FR3 = ");
-      for (j = 0; j < 4; j++)
-      {
-        fprintf (stderr, " - ");
-        for (k = 0; k < 12;)
-        {
-          int b = 0;
-          int c = 0;
-          int d = 0;
-          int e = 0;
-          b = ambe_fr3[j][k];
-          c = ambe_fr3[j][k+1];
-          d = ambe_fr3[j][k+2];
-          e = ambe_fr3[j][k+3];
-          //fprintf (stderr, "%X", (((uint8_t)ambe_fr[k] << 2) + ambe_fr[k+1]) );
-          fprintf (stderr, "%01X", ( (b << 3) + (c << 2) + (d << 1) + e ) );
-          k = k + 4;
-        }
-      }
-
-      fprintf (stderr, "\n");
-
-    }
-    */
-    //end testing fr values
     processMbeFrame (opts, state, NULL, ambe_fr, NULL);
     processMbeFrame (opts, state, NULL, ambe_fr2, NULL);
     processMbeFrame (opts, state, NULL, ambe_fr3, NULL);
@@ -476,8 +409,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
     if (internalslot == 0 && vc1 == 6)
     {
       state->dropL = 256;
-      //if (vc1 == 1 && state->payload_algid != 0 && opts->payload == 1)
-      if (state->payload_algid != 0 && opts->payload == 1)
+      if (state->payload_algid != 0 ) //&& opts->payload == 1
       {
         LFSR(state);
         fprintf (stderr, "\n");
@@ -488,7 +420,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
     if (internalslot == 1 && vc2 == 6)
     {
       state->dropR = 256;
-      if (state->payload_algidR != 0 && opts->payload == 1)
+      if (state->payload_algidR != 0 && opts->payload == 1) //&& opts->payload == 1
       {
         LFSR(state);
         fprintf (stderr, "\n");

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -273,7 +273,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       else fprintf (stderr,"Sync: -DMR  ");
       //constantly reset the vc counter to 1 each data frame in anticipation of new voice frame
       vc1 = 1;
-      state->dropL = 256;
+      //state->dropL = 256;
     }
     if (internalslot == 1)
     {
@@ -287,7 +287,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       else fprintf (stderr,"Sync: -DMR  ");
       //constantly reset the vc counter to 1 each data frame in anticipation of new voice frame
       vc2 = 1;
-      state->dropR = 256;
+      //state->dropR = 256;
     }
     processDMRdata (opts, state);
     skipcount++; //after 2 data frames, drop back to getFrameSync and process subsequent data with processDMRdata
@@ -324,11 +324,12 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
           fprintf(stderr, " BPK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
+        //the condition below should be swapped to vc6 and not on vc1, placement after processMbeFrame
         if (vc1 == 1 && state->payload_algid != 0 && opts->payload == 1)
         {
-          LFSR(state);
+          //LFSR(state); //placement here causes issues when second slot becomes active as well
         }
-        fprintf (stderr, "\n");
+        //fprintf (stderr, "\n");
       }
       else
       {
@@ -339,11 +340,12 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
           fprintf(stderr, " BPK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
+        //the condition below should be swapped to vc6 and not on vc1, placement after processMbeFrame
         if (vc1 == 1 && state->payload_algid != 0 && opts->payload == 1)
         {
-          LFSR(state);
+          //LFSR(state); //placement here causes issues when second slot becomes active as well
         }
-        fprintf (stderr, "\n");
+        //fprintf (stderr, "\n");
       }
     }
 
@@ -359,11 +361,12 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
           fprintf(stderr, " BPK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
+        //the condition below should be swapped to vc6 and not on vc1, placement after processMbeFrame
         if (vc2 == 1 && state->payload_algidR != 0 && opts->payload == 1)
         {
-          LFSR(state);
+          //LFSR(state);
         }
-        fprintf (stderr, "\n");
+        //fprintf (stderr, "\n");
       }
       else
       {
@@ -374,11 +377,12 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
           fprintf(stderr, " BPK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
+        //the condition below should be swapped to vc6 and not on vc1, placement after processMbeFrame
         if (vc2 == 1 && state->payload_algidR != 0 && opts->payload == 1)
         {
-          LFSR(state);
+          //LFSR(state);
         }
-        fprintf (stderr, "\n");
+        //fprintf (stderr, "\n");
       }
     }
     if (internalslot == 0 && vc1 == 6) //presumably when full (and no sync issues)
@@ -387,6 +391,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       ProcessVoiceBurstSync(opts, state);
       fprintf (stderr, "\n");
     }
+
     if (internalslot == 1 && vc2 == 6) //presumably when full (and no sync issues)
     {
       //process voice burst
@@ -464,29 +469,33 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
     processMbeFrame (opts, state, NULL, ambe_fr, NULL);
     processMbeFrame (opts, state, NULL, ambe_fr2, NULL);
     processMbeFrame (opts, state, NULL, ambe_fr3, NULL);
-    /*
-    if (internalslot == 0 ) //&& vc1 == 6
+
+    //We only want to run LFSR after processing VC6 frames and before rolling
+    //back to VC1, otherwise we will incur an unwanted LFSR if voice becomes active
+    //in both slots while in this loop
+    if (internalslot == 0 && vc1 == 6)
     {
-      fprintf (stderr, "\nVC%d Full = ", vc1);
-      for (k = 0; k < 144;)
+      state->dropL = 256;
+      //if (vc1 == 1 && state->payload_algid != 0 && opts->payload == 1)
+      if (state->payload_algid != 0 && opts->payload == 1)
       {
-        fprintf (stderr, "%X", ((state->dmr_stereo_payload[k] << 2) + state->dmr_stereo_payload[k+1]) );
-        k = k + 2;
+        LFSR(state);
+        fprintf (stderr, "\n");
       }
-      fprintf (stderr, "\n");
+
     }
-    if (internalslot == 1 ) //&& vc2 == 6
+
+    if (internalslot == 1 && vc2 == 6)
     {
-      fprintf (stderr, "\nVC%d Full = ", vc2);
-      for (k = 0; k < 144;)
+      state->dropR = 256;
+      if (state->payload_algidR != 0 && opts->payload == 1)
       {
-        //fprintf (stderr, " L%X R%X ", state->dmr_stereo_payload[k], state->dmr_stereo_payload[k+1]);
-        fprintf (stderr, "%01X", ((state->dmr_stereo_payload[k] << 2) + state->dmr_stereo_payload[k+1]) );
-        k = k + 2;
+        LFSR(state);
+        fprintf (stderr, "\n");
       }
-      fprintf (stderr, "\n");
+
     }
-    */
+
     if (internalslot == 0)
     {
       vc1++;
@@ -549,7 +558,9 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
  state->dmr_stereo = 0;
  state->errs2R = 0;
  state->errs2 = 0;
+//
 
+//
 }
 
 //Process buffered half frame and 2nd half and then jump to full BS decoding

--- a/src/dmr_sync.c
+++ b/src/dmr_sync.c
@@ -2096,16 +2096,16 @@ void ProcessDmrTerminaisonLC(dsd_opts * opts, dsd_state * state, uint8_t info[19
   //assuming the TLC frame comes on the same slot as the call it was terminating? not sure?
   if (state->currentslot == 0)
   {
-    state->payload_algid = 0;
-    state->payload_keyid = 0;
+    //state->payload_algid = 0; //try disablign all of these?
+    //state->payload_keyid = 0;
     //state->payload_mfid  = 0;
     //state->payload_mi    = 0; //let's try disabling this for a bit
 
   }
   if (state->currentslot == 1)
   {
-    state->payload_algidR = 0;
-    state->payload_keyidR = 0;
+    //state->payload_algidR = 0; //try disablign all of these?
+    //state->payload_keyidR = 0;
     //state->payload_mfid  = 0;
     //state->payload_miR    = 0; ////let's try disabling this for a bit
 
@@ -2582,20 +2582,26 @@ int LFSR(dsd_state * state)
   }
   if (state->currentslot == 0)
   {
-    fprintf (stderr, "%s", KYEL);
-    fprintf (stderr, "\n Slot 1");
-    fprintf (stderr, " DMR PI Continuation ALG ID: 0x%02X KEY ID: 0x%02X", state->payload_algid, state->payload_keyid);
-    fprintf(stderr, " Next MI: 0x%08X", lfsr);
-    fprintf (stderr, "%s", KNRM);
+    if (1 == 1)
+    {
+      fprintf (stderr, "%s", KYEL);
+      fprintf (stderr, "\n Slot 1");
+      fprintf (stderr, " DMR PI Continuation ALG ID: 0x%02X KEY ID: 0x%02X", state->payload_algid, state->payload_keyid);
+      fprintf(stderr, " Next MI: 0x%08X", lfsr);
+      fprintf (stderr, "%s", KNRM);
+    }
     state->payload_mi = lfsr;
   }
-  else
+  if (state->currentslot == 1) //else
   {
-    fprintf (stderr, "%s", KYEL);
-    fprintf (stderr, "\n Slot 2");
-    fprintf (stderr, " DMR PI Continuation ALG ID: 0x%02X KEY ID: 0x%02X", state->payload_algidR, state->payload_keyidR);
-    fprintf(stderr, " Next MI: 0x%08X", lfsr);
-    fprintf (stderr, "%s", KNRM);
+    if (1 == 1)
+    {
+      fprintf (stderr, "%s", KYEL);
+      fprintf (stderr, "\n Slot 2");
+      fprintf (stderr, " DMR PI Continuation ALG ID: 0x%02X KEY ID: 0x%02X", state->payload_algidR, state->payload_keyidR);
+      fprintf(stderr, " Next MI: 0x%08X", lfsr);
+      fprintf (stderr, "%s", KNRM);
+    }
     state->payload_miR = lfsr;
   }
 }
@@ -2775,90 +2781,5 @@ uint8_t ComputeCrc5Bit(uint8_t * DMRData)
   /* Return the CRC */
   return CRC;
 } /* End ComputeCrc5Bit() */
-
-
-/*
- * @brief : This function returns the Algorithm ID into an explicit string
- *
- * @param AlgID : The algorithm ID
- *   @arg : 0x21 for ARC4
- *   @arg : 0x22 for DES
- *   @arg : 0x25 for AES256
- *
- * @return A constant string pointer that explain the Alg ID used
- */
- /*
-uint8_t * DmrAlgIdToStr(uint8_t AlgID)
-{
-  if(AlgID == 0x21) return (uint8_t *)"ARC4";
-  else if(AlgID == 0x25) return (uint8_t *)"AES256";
-  else return (uint8_t *)"UNKNOWN";
-  //state->payload_algid = AlgID;
-} // End DmrAlgIdToStr
-*/
-
-/*
- * @brief : This function returns the encryption mode into an explicit string
- *
- * @param PrivacyMode : The algorithm ID
- *   @arg : MODE_UNENCRYPTED
- *   @arg : MODE_BASIC_PRIVACY
- *   @arg : MODE_ENHANCED_PRIVACY_ARC4
- *   @arg : MODE_ENHANCED_PRIVACY_DES
- *   @arg : MODE_ENHANCED_PRIVACY_AES256
- *   @arg : MODE_HYTERA_BASIC_40_BIT
- *   @arg : MODE_HYTERA_BASIC_128_BIT
- *   @arg : MODE_HYTERA_BASIC_256_BIT
- *
- * @return A constant string pointer that explain the encryption mode used
- */
- /*
-uint8_t * DmrAlgPrivacyModeToStr(uint32_t PrivacyMode)
-{
-  switch(PrivacyMode)
-  {
-    case MODE_UNENCRYPTED:
-    {
-      return (uint8_t *)"NOT ENC";
-      break;
-    }
-    case MODE_BASIC_PRIVACY:
-    {
-      return (uint8_t *)"BP";
-      break;
-    }
-    case MODE_ENHANCED_PRIVACY_ARC4:
-    {
-      return (uint8_t *)"EP ARC4";
-      break;
-    }
-    case MODE_ENHANCED_PRIVACY_AES256:
-    {
-      return (uint8_t *)"EP AES256";
-      break;
-    }
-    case MODE_HYTERA_BASIC_40_BIT:
-    {
-      return (uint8_t *)"HYTERA BASIC 40 BIT";
-      break;
-    }
-    case MODE_HYTERA_BASIC_128_BIT:
-    {
-      return (uint8_t *)"HYTERA BASIC 128 BIT";
-      break;
-    }
-    case MODE_HYTERA_BASIC_256_BIT:
-    {
-      return (uint8_t *)"HYTERA BASIC 256 BIT";
-      break;
-    }
-    default:
-    {
-      return (uint8_t *)"UNKNOWN";
-      break;
-    }
-  } // End switch(PrivacyMode) /
-} //End DmrAlgPrivacyModeToStr() /
-*/
 
 /* End of file */

--- a/src/dmr_voice.c
+++ b/src/dmr_voice.c
@@ -646,8 +646,8 @@ void processDMRvoice (dsd_opts * opts, dsd_state * state)
   ProcessDMR(opts, state);
 
   //LFSR if required, change condition?
-  if ( (state->currentslot == 0 && state->payload_algid  != 0 && opts->payload == 1) ||
-       (state->currentslot == 1 && state->payload_algidR != 0 && opts->payload == 1)  )
+  if ( (state->currentslot == 0 && state->payload_algid  != 0 ) ||  //&& opts->payload == 1
+       (state->currentslot == 1 && state->payload_algidR != 0 )  ) //&& opts->payload == 1
   {
     LFSR(state);
   }

--- a/src/dsd_audio.c
+++ b/src/dsd_audio.c
@@ -49,8 +49,8 @@ void openPulseOutput(dsd_opts * opts)
   }
   if (opts->dmr_stereo == 1)
   {
-    opts->pulse_digi_dev_out  = pa_simple_new(NULL, "DSD-FME", PA_STREAM_PLAYBACK, NULL, "DMR/MOTOTRBO  LEFT", &tt, left, NULL, NULL);
-    opts->pulse_digi_dev_outR = pa_simple_new(NULL, "DSD-FME", PA_STREAM_PLAYBACK, NULL, "DMR/MOTOTRBO RIGHT", &tt, right, NULL, NULL);
+    opts->pulse_digi_dev_out  = pa_simple_new(NULL, "DSD-FME1", PA_STREAM_PLAYBACK, NULL, "DMR/MOTOTRBO SLOT 1", &tt, left, NULL, NULL);
+    opts->pulse_digi_dev_outR = pa_simple_new(NULL, "DSD-FME2", PA_STREAM_PLAYBACK, NULL, "DMR/MOTOTRBO SLOT 2", &tt, right, NULL, NULL);
   }
 
 }
@@ -158,7 +158,7 @@ processAudio (dsd_opts * opts, dsd_state * state)
   state->audio_out_temp_buf_p = state->audio_out_temp_buf;
   //we only want to upsample when using sample rates greater than 8k for output,
   //hard set to 8k for RTL mono and MBE playback, otherwise crackling may occur.
-  if (opts->pulse_digi_rate_out > 8000) 
+  if (opts->pulse_digi_rate_out > 8000)
     {
       for (n = 0; n < 160; n++)
         {


### PR DESCRIPTION
--Tweak Naming of DMR Stereo output streams, giving them unique names so that the pulse audio server will remember their audio levels and left and right channel configurations on subsequent start ups.

--Tweak timing of events inside of the DMR BS Stereo Method