### PR TITLE
Muting Enc Tweaks; LRRP getDateL tweak;

### DIFF
--- a/src/dmr_process_voice.c
+++ b/src/dmr_process_voice.c
@@ -144,6 +144,12 @@ if (state->currentslot == 0)
         state->dmr_encL = 1;
       }
       else state->dmr_encL = 0;
+
+      if (state->K != 0)
+			{
+				state->dmr_encL = 0;
+			}
+
       //quick test to determine whether or not to run the next few steps below
       if (state->dmr_encL == 0 || opts->dmr_mute_encL == 0)
       {
@@ -202,6 +208,11 @@ if (state->currentslot == 0)
        }
        else state->dmr_encR = 0;
 
+       if (state->K != 0 || state->R != 0)
+ 			 {
+ 				state->dmr_encR = 0;
+ 			 }
+       
        //quick test to determine whether or not to run the next few steps below
        if (state->dmr_encR == 0 || opts->dmr_mute_encR == 0)
        {

--- a/src/dmr_process_voice.c
+++ b/src/dmr_process_voice.c
@@ -208,11 +208,11 @@ if (state->currentslot == 0)
        }
        else state->dmr_encR = 0;
 
-       if (state->K != 0 || state->R != 0)
+       if (state->K != 0)
  			 {
  				state->dmr_encR = 0;
  			 }
-       
+
        //quick test to determine whether or not to run the next few steps below
        if (state->dmr_encR == 0 || opts->dmr_mute_encR == 0)
        {

--- a/src/dmr_sync.c
+++ b/src/dmr_sync.c
@@ -35,7 +35,7 @@ char * getTimeL(void) //get pretty hh:mm:ss timestamp
 //getDate has a bug that affects writing to file using fopen 32-bit Ubuntu OS, need to look into
 //increasing array size causes date to not print in Linux builds, but fixes cygwin bug, so reverting to 99 until a better fix is worked out.
 char * getDateL(void) {
-  char datename[99]; //increased to 200 to fix 32-bit Ubuntu/Cygwin when fopen file printing to lrrp.txt
+  char datename[120]; //increased to 200 to fix 32-bit Ubuntu/Cygwin when fopen file printing to lrrp.txt
   char * curr2;
   struct tm * to;
   time_t t;

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -204,18 +204,12 @@ initOpts (dsd_opts * opts)
   opts->p25status = 0;
   opts->p25tg = 0;
   opts->scoperate = 15;
-  //sprintf (opts->audio_in_dev, "/dev/audio");
   sprintf (opts->audio_in_dev, "pulse");
   opts->audio_in_fd = -1;
-// #ifdef USE_PORTAUDIO
-//   opts->audio_in_pa_stream = NULL;
-// #endif
-  //sprintf (opts->audio_out_dev, "/dev/audio");
+
   sprintf (opts->audio_out_dev, "pulse");
   opts->audio_out_fd = -1;
-// #ifdef USE_PORTAUDIO
-//   opts->audio_out_pa_stream = NULL;
-// #endif
+
   opts->split = 0;
   opts->playoffset = 0;
   opts->playoffsetR = 0;

--- a/src/dsd_mbe.c
+++ b/src/dsd_mbe.c
@@ -155,7 +155,7 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
 			//increment vc counter by one.
 			state->p25vc++;
 
-      if (opts->mbe_out_f != NULL)
+      if (opts->mbe_out_f != NULL && state->dmr_encL == 0) //only save if this bit not set
       {
         saveImbe4400Data (opts, state, imbe_d);
       }
@@ -211,7 +211,7 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
 			PrintAMBEData (opts, state, ambe_d);
 		}
 
-		if (opts->mbe_out_f != NULL)
+		if (opts->mbe_out_f != NULL && (state->dmr_encL == 0 || opts->dmr_mute_encL == 0) )
 		{
 			saveAmbe2450Data (opts, state, ambe_d);
 		}
@@ -300,10 +300,6 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
 
 
     }
-
-  //having these values here I think caused muddy audio, seems cleaner now when moved to correct area
-  // state->debug_audio_errors += state->errs2;
-  // state->debug_audio_errorsR += state->errs2R;
 
   //quick enc check to determine whether or not to play enc traffic
   int enc_bit = 0;


### PR DESCRIPTION
Muting Enc Tweaks
--Tweak when to mute and unmute encrypted traffic, and when to write wav and mbe files when enc or not
--If any DMR traffic appears muted that shouldn't be, simply toggle the mute in ncurses menu
LRRP getDateL tweak
--expand array from 99 to 120; seems to be usable in both Linux Desktop and Cygwin this way, most tests required.