### PR TITLE
DMR Additions

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -563,6 +563,11 @@ typedef struct
   unsigned int dmrburstL;
   unsigned int dmrburstR;
   unsigned long long int R;
+  unsigned long long int H;
+  unsigned long long int HYTL;
+  unsigned long long int HYTR;
+  int DMRvcL;
+  int DMRvcR;
   // int block_count;
   short int dmr_encL;
   short int dmr_encR;
@@ -887,11 +892,13 @@ void dstar_header_decode(dsd_state * state, int radioheaderbuffer[660]);
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef USE_RTLSDR
 void open_rtlsdr_stream(dsd_opts *opts);
 void cleanup_rtlsdr_stream();
 void get_rtlsdr_sample(int16_t *sample, dsd_opts * opts, dsd_state * state);
 void rtlsdr_sighandler();
-
+#endif
 //TRELLIS
 void CDMRTrellisTribitsToBits(const unsigned char* tribits, unsigned char* payload);
 unsigned int CDMRTrellisCheckCode(const unsigned char* points, unsigned char* tribits);

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -368,10 +368,16 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       if (opts->inverted_dmr == 0)
       {
         fprintf (stderr,"Sync: +DMR  [SLOT1]  slot2  |               | DMRSTEREO | VC%d ",vc1);
-        if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0)
+        if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
           fprintf(stderr, " BPK %lld", state->K);
+          fprintf (stderr, "%s", KNRM);
+        }
+        if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
+        {
+          fprintf (stderr, "%s", KYEL);
+          fprintf(stderr, " T10 %010llX", state->H);
           fprintf (stderr, "%s", KNRM);
         }
         fprintf (stderr, "\n");
@@ -379,10 +385,16 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       else
       {
         fprintf (stderr,"Sync: -DMR  [SLOT1]  slot2  |               | DMRSTEREO | VC%d ",vc1);
-        if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0)
+        if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
           fprintf(stderr, " BPK %lld", state->K);
+          fprintf (stderr, "%s", KNRM);
+        }
+        if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
+        {
+          fprintf (stderr, "%s", KYEL);
+          fprintf(stderr, " T10 %010llX", state->H);
           fprintf (stderr, "%s", KNRM);
         }
         fprintf (stderr, "\n");
@@ -395,10 +407,16 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       if (opts->inverted_dmr == 0)
       {
         fprintf (stderr,"Sync: +DMR   slot1  [SLOT2] |               | DMRSTEREO | VC%d ",vc2);
-        if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0)
+        if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
           fprintf(stderr, " BPK %lld", state->K);
+          fprintf (stderr, "%s", KNRM);
+        }
+        if (state->H > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68)
+        {
+          fprintf (stderr, "%s", KYEL);
+          fprintf(stderr, " T10 %010llX", state->H);
           fprintf (stderr, "%s", KNRM);
         }
         fprintf (stderr, "\n");
@@ -406,10 +424,16 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
       else
       {
         fprintf (stderr,"Sync: -DMR   slot1  [SLOT2] |               | DMRSTEREO | VC%d ",vc2);
-        if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0)
+        if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
           fprintf(stderr, " BPK %lld", state->K);
+          fprintf (stderr, "%s", KNRM);
+        }
+        if (state->H > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68)
+        {
+          fprintf (stderr, "%s", KYEL);
+          fprintf(stderr, " T10 %010llX", state->H);
           fprintf (stderr, "%s", KNRM);
         }
         fprintf (stderr, "\n");
@@ -435,10 +459,10 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
 
     if (internalslot == 0 && vc1 == 6)
     {
-
+      state->DMRvcL = 0;
       if (state->payload_algid >= 0x21)
       {
-        //running this as state->payload_mi > 0 apparently causes some problem, don't know why
+
         if (state->payload_mi != 0 && state->payload_algid >= 0x21)
         {
           LFSR(state);
@@ -449,12 +473,12 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
 
     if (internalslot == 1 && vc2 == 6)
     {
-
+      state->DMRvcR = 0;
       if (state->payload_algidR >= 0x21)
       {
         if (state->payload_miR != 0 && state->payload_algidR == 0x21)
         {
-          LFSR(state); //re-enable this one after testing Late Entry MI
+          LFSR(state);
         }
         fprintf (stderr, "\n");
       }
@@ -565,8 +589,8 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
 
   //payload buffer
   //CACH + First Half Payload + Sync = 12 + 54 + 24
-  dibit_p = state->dibit_buf_p - 90; //this seems to work okay for both
-  //dibit_p = state->dmr_payload_p - 90;
+  //dibit_p = state->dibit_buf_p - 90; //this seems to work okay for both
+  dibit_p = state->dmr_payload_p - 90;
   for (i = 0; i < 90; i++) //90
   {
     dibit = *dibit_p;
@@ -709,6 +733,9 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
     }
     fprintf (stderr, "\n");
   }
+
+  state->DMRvcL = 0;
+  state->DMRvcR = 0;
 
   processMbeFrame (opts, state, NULL, ambe_fr, NULL);
   processMbeFrame (opts, state, NULL, ambe_fr2, NULL);

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -371,7 +371,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
-          fprintf(stderr, " BPK %lld", state->K);
+          fprintf(stderr, " PrK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
         if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
@@ -388,7 +388,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
-          fprintf(stderr, " BPK %lld", state->K);
+          fprintf(stderr, " PrK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
         if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
@@ -410,7 +410,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
-          fprintf(stderr, " BPK %lld", state->K);
+          fprintf(stderr, " PrK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
         if (state->H > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68)
@@ -427,7 +427,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
         if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
         {
           fprintf (stderr, "%s", KYEL);
-          fprintf(stderr, " BPK %lld", state->K);
+          fprintf(stderr, " PrK %lld", state->K);
           fprintf (stderr, "%s", KNRM);
         }
         if (state->H > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68)
@@ -714,7 +714,7 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
          (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10) )
     {
       fprintf (stderr, "%s", KYEL);
-      fprintf(stderr, " BPK %lld", state->K);
+      fprintf(stderr, " PrK %lld", state->K);
       fprintf (stderr, "%s", KNRM);
 
     }
@@ -734,9 +734,9 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
          (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10) )
     {
       fprintf (stderr, "%s", KYEL);
-      fprintf(stderr, " BPK %lld", state->K);
+      fprintf(stderr, " PrK %lld", state->K);
       fprintf (stderr, "%s", KNRM);
-      
+
     }
     if ( (state->H > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid  == 0x68) ||
          (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68) )

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -710,26 +710,40 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
   if (opts->inverted_dmr == 0)
   {
     fprintf (stderr,"Sync: +DMR                  |  Frame Sync   | DMRSTEREO | VC1 ");
-    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0) ||
-         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0) )
+    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid  == 0x10) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10) )
     {
       fprintf (stderr, "%s", KYEL);
       fprintf(stderr, " BPK %lld", state->K);
       fprintf (stderr, "%s", KNRM);
-      //state->currentslot = 0; //slot now set from cach data from buffer
+
+    }
+    if ( (state->H > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid  == 0x68) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68) )
+    {
+      fprintf (stderr, "%s", KYEL);
+      fprintf(stderr, " T10 %010llX", state->H);
+      fprintf (stderr, "%s", KNRM);
     }
     fprintf (stderr, "\n");
   }
   else
   {
     fprintf (stderr,"Sync: -DMR                  |  Frame Sync   | DMRSTEREO | VC1 ");
-    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0) ||
-         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0) )
+    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid  == 0x10) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10) )
     {
       fprintf (stderr, "%s", KYEL);
       fprintf(stderr, " BPK %lld", state->K);
       fprintf (stderr, "%s", KNRM);
-      //state->currentslot = 0; //slot now set from cach data from buffer
+      
+    }
+    if ( (state->H > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid  == 0x68) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68) )
+    {
+      fprintf (stderr, "%s", KYEL);
+      fprintf(stderr, " T10 %010llX", state->H);
+      fprintf (stderr, "%s", KNRM);
     }
     fprintf (stderr, "\n");
   }

--- a/src/dmr_data.c
+++ b/src/dmr_data.c
@@ -51,15 +51,15 @@ processDMRdata (dsd_opts * opts, dsd_state * state)
   ccAscii[4] = 0;
   bursttype[4] = 0;
 
-  dibit_p = state->dibit_buf_p - 90;
+  //dibit_p = state->dibit_buf_p - 90;
   //using the estimate_symbol method for the dmr_payload_p buffer causes sync
   //issues with P25, so only do it when frame_p25p1 == 0, or -fr option
   //temp fix to only use dmr_payload_p buffer when no inversion expected, otherwise use dibit_buf
-  if (opts->frame_p25p1 == 0 && opts->inverted_dmr == 0) //opts->frame_p25p1 == 0 && opts->inverted_dmr == 0
-  {
-    dibit_p = state->dmr_payload_p - 90;
-  }
-
+  // if (opts->frame_p25p1 == 0 && opts->inverted_dmr == 0) //opts->frame_p25p1 == 0 && opts->inverted_dmr == 0
+  // {
+  //   dibit_p = state->dmr_payload_p - 90;
+  // }
+  dibit_p = state->dmr_payload_p - 90;
   // CACH, why aren't we running any FEC on this?
   for (i = 0; i < 12; i++)
   {

--- a/src/dmr_ms.c
+++ b/src/dmr_ms.c
@@ -366,10 +366,16 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
     if (internalslot == 0 && opts->inverted_dmr == 0)
     {
       fprintf (stderr,"Sync: +DMR MS MODE | Color Code=%02d | DMRSTEREO | VC%d ", state->color_code, vc1);
-      if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0)
+      if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
       {
         fprintf (stderr, "%s", KYEL);
         fprintf(stderr, " BPK %lld", state->K);
+        fprintf (stderr, "%s", KNRM);
+      }
+      if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
+      {
+        fprintf (stderr, "%s", KYEL);
+        fprintf(stderr, " T10 %010llX", state->H);
         fprintf (stderr, "%s", KNRM);
       }
       fprintf (stderr, "\n");
@@ -378,10 +384,16 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
     if (internalslot == 0 && opts->inverted_dmr == 1)
     {
       fprintf (stderr,"Sync: -DMR MS MODE | Color Code=%02d | DMRSTEREO | VC%d ", state->color_code, vc1);
-      if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0)
+      if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
       {
         fprintf (stderr, "%s", KYEL);
         fprintf(stderr, " BPK %lld", state->K);
+        fprintf (stderr, "%s", KNRM);
+      }
+      if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
+      {
+        fprintf (stderr, "%s", KYEL);
+        fprintf(stderr, " T10 %010llX", state->H);
         fprintf (stderr, "%s", KNRM);
       }
       fprintf (stderr, "\n");
@@ -400,10 +412,9 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
     processMbeFrame (opts, state, NULL, ambe_fr2, NULL);
     processMbeFrame (opts, state, NULL, ambe_fr3, NULL);
 
-    //need to seperate the algs here so we don't run LFSR on 22 and so on
     if (vc1 == 6 && state->payload_algid >= 21)
     {
-       //state->currentslot = 0;
+       state->DMRvcL = 0;
        if (state->payload_mi != 0 && state->payload_algid >= 0x21)
        {
          LFSR(state);
@@ -614,11 +625,18 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
   if (opts->inverted_dmr == 0)
   {
     fprintf (stderr,"Sync: +DMR MS MODE |  Frame Sync   | DMRSTEREO | VC1 ");
-    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0) ||
-         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0) )
+    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid == 0x10) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x10)  )
     {
       fprintf (stderr, "%s", KYEL);
       fprintf(stderr, " BPK %lld", state->K);
+      fprintf (stderr, "%s", KNRM);
+    }
+    if ( (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x68)  )
+    {
+      fprintf (stderr, "%s", KYEL);
+      fprintf(stderr, " T10 %010llX", state->H);
       fprintf (stderr, "%s", KNRM);
     }
     fprintf (stderr, "\n");
@@ -626,17 +644,25 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
   else
   {
     fprintf (stderr,"Sync: -DMR MS MODE |  Frame Sync   | DMRSTEREO | VC1 ");
-    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0) ||
-         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0) )
+    if ( (state->K > 0 && state->dmr_so  & 0x40 && state->payload_keyid  == 0 && state->dmr_fid == 0x10) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x10) )
     {
       fprintf (stderr, "%s", KYEL);
       fprintf(stderr, " BPK %lld", state->K);
+      fprintf (stderr, "%s", KNRM);
+    }
+    if ( (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68) ||
+         (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x68)  )
+    {
+      fprintf (stderr, "%s", KYEL);
+      fprintf(stderr, " T10 %010llX", state->H);
       fprintf (stderr, "%s", KNRM);
     }
     fprintf (stderr, "\n");
   }
 
   state->dmr_ms_mode = 1;
+  state->DMRvcL = 0;
 
   processMbeFrame (opts, state, NULL, ambe_fr, NULL);
   processMbeFrame (opts, state, NULL, ambe_fr2, NULL);

--- a/src/dmr_ms.c
+++ b/src/dmr_ms.c
@@ -369,7 +369,7 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
       if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
       {
         fprintf (stderr, "%s", KYEL);
-        fprintf(stderr, " BPK %lld", state->K);
+        fprintf(stderr, " PrK %lld", state->K);
         fprintf (stderr, "%s", KNRM);
       }
       if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
@@ -387,7 +387,7 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
       if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
       {
         fprintf (stderr, "%s", KYEL);
-        fprintf(stderr, " BPK %lld", state->K);
+        fprintf(stderr, " PrK %lld", state->K);
         fprintf (stderr, "%s", KNRM);
       }
       if (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
@@ -629,7 +629,7 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
          (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x10)  )
     {
       fprintf (stderr, "%s", KYEL);
-      fprintf(stderr, " BPK %lld", state->K);
+      fprintf(stderr, " PrK %lld", state->K);
       fprintf (stderr, "%s", KNRM);
     }
     if ( (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68) ||
@@ -648,7 +648,7 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
          (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x10) )
     {
       fprintf (stderr, "%s", KYEL);
-      fprintf(stderr, " BPK %lld", state->K);
+      fprintf(stderr, " PrK %lld", state->K);
       fprintf (stderr, "%s", KNRM);
     }
     if ( (state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68) ||

--- a/src/dmr_process_voice.c
+++ b/src/dmr_process_voice.c
@@ -118,7 +118,7 @@ if (state->currentslot == 0 && state->H > 0 && state->dmr_so & 0x40 && state->pa
 {
 
 	fprintf (stderr, "%s", KYEL);
-	fprintf(stderr, " HYT %010llX", state->H);
+	fprintf(stderr, " T10 %010llX", state->H);
 	fprintf (stderr, "%s", KNRM);
 	k = state->H;
 
@@ -150,7 +150,7 @@ if (state->currentslot == 1 && state->H > 0 && state->dmr_soR & 0x40 && state->p
 {
 
 	fprintf (stderr, "%s", KYEL);
-	fprintf(stderr, " HYT %010llX", state->H);
+	fprintf(stderr, " T10 %010llX", state->H);
 	fprintf (stderr, "%s", KNRM);
 	k = state->H;
 

--- a/src/dmr_process_voice.c
+++ b/src/dmr_process_voice.c
@@ -72,7 +72,7 @@ int BP[256] = {
 };
 
 
-if (state->currentslot == 0 && state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0)
+if (state->currentslot == 0 && state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
 {
   fprintf (stderr, "%s", KYEL);
   fprintf(stderr, " BPK %lld", state->K);
@@ -93,7 +93,7 @@ if (state->currentslot == 0 && state->K > 0 && state->dmr_so & 0x40 && state->pa
   }
 }
 
-if (state->currentslot == 1 && state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0)
+if (state->currentslot == 1 && state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
 {
   fprintf (stderr, "%s", KYEL);
   fprintf(stderr, " BPK %lld", state->K);
@@ -110,6 +110,70 @@ if (state->currentslot == 1 && state->K > 0 && state->dmr_soR & 0x40 && state->p
       x = ( ((k << j) & 0x800000000000) >> 47 );
       TSVoiceSupFrameR->TimeSlotAmbeVoiceFrame[Frame].AmbeBit[i][j] ^= x;
      }
+   }
+  }
+}
+
+if (state->currentslot == 0 && state->H > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x68)
+{
+
+	fprintf (stderr, "%s", KYEL);
+	fprintf(stderr, " HYT %010llX", state->H);
+	fprintf (stderr, "%s", KNRM);
+	k = state->H;
+
+	unsigned long long int msb = 0;
+
+	k = k << 8;
+	k = k | ((k >> 40) & 0xFF);
+
+  for(Frame = 0; Frame < 6; Frame++)
+  {
+   for(i = 0; i < 3; i++)
+   {
+     for(j = 0; j < 48; j++)
+     {
+      x = ( ((k << j) & 0x800000000000) >> 47 );
+      TSVoiceSupFrameL->TimeSlotAmbeVoiceFrame[Frame].AmbeBit[i][j] ^= x;
+     }
+
+			k = k << 1;
+			msb = (k >> 32) & 0xFFFF;
+			k = (k << 8) & 0xFFFFFFFF0000;
+			k = k | msb;
+
+   }
+  }
+}
+
+if (state->currentslot == 1 && state->H > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x68)
+{
+
+	fprintf (stderr, "%s", KYEL);
+	fprintf(stderr, " HYT %010llX", state->H);
+	fprintf (stderr, "%s", KNRM);
+	k = state->H;
+
+	unsigned long long int msb = 0;
+
+	k = k << 8;
+	k = k | ((k >> 40) & 0xFF);
+
+  for(Frame = 0; Frame < 6; Frame++)
+  {
+   for(i = 0; i < 3; i++)
+   {
+     for(j = 0; j < 48; j++)
+     {
+      x = ( ((k << j) & 0x800000000000) >> 47 );
+      TSVoiceSupFrameR->TimeSlotAmbeVoiceFrame[Frame].AmbeBit[i][j] ^= x;
+     }
+
+			k = k << 1;
+			msb = (k >> 32) & 0xFFFF;
+			k = (k << 8) & 0xFFFFFFFF0000;
+			k = k | msb;
+
    }
   }
 }

--- a/src/dmr_process_voice.c
+++ b/src/dmr_process_voice.c
@@ -36,7 +36,7 @@ void ProcessDMR (dsd_opts * opts, dsd_state * state)
   TSVoiceSupFrameL = &state->TS1SuperFrame;
   TSVoiceSupFrameR = &state->TS2SuperFrame;
 
-int BP[256] = {
+int Pr[256] = {
   0x0000, 0x1F00, 0xE300, 0xFC00, 0x2503, 0x3A03, 0xC603, 0xD903,
   0x4A05, 0x5505, 0xA905, 0xB605, 0x6F06, 0x7006, 0x8C06, 0x9306,
   0x2618, 0x3918, 0xC518, 0xDA18, 0x031B, 0x1C1B, 0xE01B, 0xFF1B,
@@ -75,9 +75,9 @@ int BP[256] = {
 if (state->currentslot == 0 && state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
 {
   fprintf (stderr, "%s", KYEL);
-  fprintf(stderr, " BPK %lld", state->K);
+  fprintf(stderr, " PrK %lld", state->K);
   fprintf (stderr, "%s", KNRM);
-  k = BP[state->K];
+  k = Pr[state->K];
   k = ( ((k & 0xFF0F) << 32 ) + (k << 16) + k );
 
   for(Frame = 0; Frame < 6; Frame++)
@@ -96,9 +96,9 @@ if (state->currentslot == 0 && state->K > 0 && state->dmr_so & 0x40 && state->pa
 if (state->currentslot == 1 && state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
 {
   fprintf (stderr, "%s", KYEL);
-  fprintf(stderr, " BPK %lld", state->K);
+  fprintf(stderr, " PrK %lld", state->K);
   fprintf (stderr, "%s", KNRM);
-  k = BP[state->K];
+  k = Pr[state->K];
   k = ( ((k & 0xFF0F) << 32 ) + (k << 16) + k );
 
   for(Frame = 0; Frame < 6; Frame++)

--- a/src/dmr_sync.c
+++ b/src/dmr_sync.c
@@ -1618,7 +1618,7 @@ void ProcessCSBK(dsd_opts * opts, dsd_state * state, uint8_t info[196], uint8_t 
     uint8_t nb4 = DmrDataByte[5] & 0x3F; //extract(csbk, 42, 48);
     uint8_t nb5 = DmrDataByte[6] & 0x3F; //extract(csbk, 50, 56);
     fprintf (stderr, "\nMotoTRBO Capacity Plus Neighbors");
-    //fprintf(stderr, " NB1(%02x), NB2(%02x), NB3(%02x), NB4(%02x), NB5(%02x)", nb1, nb2, nb3, nb4, nb5);
+    fprintf(stderr, " NB1(%02x), NB2(%02x), NB3(%02x), NB4(%02x), NB5(%02x)", nb1, nb2, nb3, nb4, nb5);
     sprintf(state->dmr_branding, " MotoTRBO Capacity Plus ");
   }
 
@@ -1842,6 +1842,9 @@ void ProcessDmrPIHeader(dsd_opts * opts, dsd_state * state, uint8_t info[196], u
 
 }
 
+//need to look into differences with Cap+ and other systems affecting the expected radio src id values
+//find a way to differentiate the system types so we get good radio id decodes all the time
+//svc op 0x60 for cap+?? if so, then should we use a mask?
 void ProcessDmrVoiceLcHeader(dsd_opts * opts, dsd_state * state, uint8_t info[196], uint8_t syncdata[48], uint8_t SlotType[20])
 {
   uint32_t i, j, k;
@@ -1861,7 +1864,7 @@ void ProcessDmrVoiceLcHeader(dsd_opts * opts, dsd_state * state, uint8_t info[19
   {
     TSVoiceSupFrame = &state->TS1SuperFrame;
   }
-  else
+  if(state->currentslot == 1)
   {
     TSVoiceSupFrame = &state->TS2SuperFrame;
   }
@@ -1948,15 +1951,15 @@ void ProcessDmrVoiceLcHeader(dsd_opts * opts, dsd_state * state, uint8_t info[19
     {
       state->dmr_fid = TSVoiceSupFrame->FullLC.FeatureSetID;
       state->dmr_so = TSVoiceSupFrame->FullLC.ServiceOptions;
-      state->lasttg = TSVoiceSupFrame->FullLC.GroupAddress;
-      state->lastsrc = TSVoiceSupFrame->FullLC.SourceAddress;
+      //state->lasttg = TSVoiceSupFrame->FullLC.GroupAddress;
+      //state->lastsrc = TSVoiceSupFrame->FullLC.SourceAddress; //disabled for now, Cap+ and other systems cause issues with these values
     }
     if (state->currentslot == 1)
     {
       state->dmr_fidR = TSVoiceSupFrame->FullLC.FeatureSetID;
       state->dmr_soR = TSVoiceSupFrame->FullLC.ServiceOptions;
-      state->lasttgR = TSVoiceSupFrame->FullLC.GroupAddress;
-      state->lastsrcR = TSVoiceSupFrame->FullLC.SourceAddress;
+      //state->lasttgR = TSVoiceSupFrame->FullLC.GroupAddress;
+      //state->lastsrcR = TSVoiceSupFrame->FullLC.SourceAddress;
     }
   }
   else if(IrrecoverableErrors == 0)
@@ -1967,15 +1970,15 @@ void ProcessDmrVoiceLcHeader(dsd_opts * opts, dsd_state * state, uint8_t info[19
     {
       state->dmr_fid = TSVoiceSupFrame->FullLC.FeatureSetID;
       state->dmr_so = TSVoiceSupFrame->FullLC.ServiceOptions;
-      state->lasttg = TSVoiceSupFrame->FullLC.GroupAddress;
-      state->lastsrc = TSVoiceSupFrame->FullLC.SourceAddress;
+      //state->lasttg = TSVoiceSupFrame->FullLC.GroupAddress;
+      //state->lastsrc = TSVoiceSupFrame->FullLC.SourceAddress;
     }
     if (state->currentslot == 1)
     {
       state->dmr_fidR = TSVoiceSupFrame->FullLC.FeatureSetID;
       state->dmr_soR = TSVoiceSupFrame->FullLC.ServiceOptions;
-      state->lasttgR = TSVoiceSupFrame->FullLC.GroupAddress;
-      state->lastsrcR = TSVoiceSupFrame->FullLC.SourceAddress;
+      //state->lasttgR = TSVoiceSupFrame->FullLC.GroupAddress;
+      //state->lastsrcR = TSVoiceSupFrame->FullLC.SourceAddress;
     }
   }
   else
@@ -2359,14 +2362,12 @@ void ProcessVoiceBurstSync(dsd_opts * opts, dsd_state * state)
   for(i = 0; i < 10; i++)
   {
     LC_DataBytes[i] = 0;
-    for(j = 0; j < 8; j++)
-    //for(j = 0; j < 10; j++)
+    for(j = 0; j < 10; j++) //why did I change this?
     {
       LC_DataBytes[i] = LC_DataBytes[i] << 1;
       LC_DataBytes[i] = LC_DataBytes[i] | (LC_DataBit[k] & 0x01);
       k++;
       if(k >= 76) break;
-      //if(k >= 80) break;
     }
   }
 

--- a/src/dsd_dibit.c
+++ b/src/dsd_dibit.c
@@ -318,6 +318,13 @@ static int digitize (dsd_opts* opts, dsd_state* state, int symbol)
       // store non-inverted values in dibit_buf
       *state->dibit_buf_p = invert_dibit(dibit);
       state->dibit_buf_p++;
+
+      //dmr buffer
+      *state->dmr_payload_p = invert_dibit(dibit); //invert, or no?
+      // *state->dmr_payload_p = dibit; //invert, or no?
+      state->dmr_payload_p++;
+      //dmr buffer end
+
       return dibit;
     }
   else

--- a/src/dsd_frame_sync.c
+++ b/src/dsd_frame_sync.c
@@ -295,14 +295,14 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
     	 state->dmr_payload_p = state->dmr_payload_buf + 200;
       }
 
-      int valid;
+      // int valid;
       //running estimate_symbol causes an issue with P25 syncing properly
-      if (opts->frame_p25p1 != 1)
-      {
-        valid = estimate_symbol(state->rf_mod, &(state->p25_heuristics), state->last_dibit, symbol, &dibit);
-      }
+      // if (opts->frame_p25p1 != 1)
+      // {
+      //   valid = estimate_symbol(state->rf_mod, &(state->p25_heuristics), state->last_dibit, symbol, &dibit);
+      // }
 
-      if (opts->frame_dmr == 1 && valid == 0) //opts->dmr_stereo
+      if (1 == 1) //opts->dmr_stereo //opts->frame_dmr == 1 && valid == 0
       {
         if (symbol > state->center)
         {

--- a/src/dsd_frame_sync.c
+++ b/src/dsd_frame_sync.c
@@ -1197,7 +1197,7 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
                           }
                           if (opts->errorbars == 1)
                             {
-                              printFrameSync (opts, state, " +NXDN96   ", synctest_pos + 1, modulation);
+                              printFrameSync (opts, state, "+NXDN96 ", synctest_pos + 1, modulation);
                             }
                         }
                       state->lastsynctype = 8;

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -634,7 +634,7 @@ usage ()
   printf ("\n");
   printf ("  -K <dec>      Manually Enter DMRA BP Key (Decimal Value of Key Number)\n");
   printf ("\n");
-  printf ("  -H <hex>      Manually Enter **tera 10 BP Key (40-Bit/10-Char Hex Value)\n");
+  printf ("  -H <hex>      Manually Enter Terra 10 BP Key (40-Bit/10-Char Hex Value)\n");
   printf ("\n");
   exit (0);
 }

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -144,6 +144,16 @@ noCarrier (dsd_opts * opts, dsd_state * state)
   state->payload_keyid = 0;
   state->payload_keyidR = 0;
 
+  state->dmr_fid = 0;
+  state->dmr_so = 0;
+  state->dmr_fidR = 0;
+  state->dmr_soR = 0;
+
+  state->HYTL = 0;
+  state->HYTR = 0;
+  state->DMRvcL = 0;
+  state->DMRvcR = 0;
+
   state->payload_miN = 0;
   state->p25vc = 0;
   state->payload_miP = 0;
@@ -469,6 +479,7 @@ initState (dsd_state * state)
 
   state->K = 0;
   state->R = 0;
+  state->H = 0;
 
   state->dmr_stereo = 0;
   state->dmrburstL = 17; //initialize at higher value than possible
@@ -478,6 +489,11 @@ initState (dsd_state * state)
   state->dmr_fid  = 0;
   state->dmr_fidR = 0;
   state->dmr_ms_mode = 0;
+
+  state->HYTL = 0;
+  state->HYTR = 0;
+  state->DMRvcL = 0;
+  state->DMRvcR = 0;
 
   state->p25vc = 0;
 
@@ -615,6 +631,10 @@ usage ()
   printf ("                 This feature will attempt to resync less often due to excessive voice errors\n");
   printf ("                 Use if skipping occurs, but may cause wonky audio due to loss of good sync\n");
   printf ("  -Z            Log MBE/Frame Payloads to console\n");
+  printf ("\n");
+  printf ("  -K <dec>      Manually Enter DMRA BP Key (Decimal Value of Key Number)\n");
+  printf ("\n");
+  printf ("  -H <hex>      Manually Enter **tera 10 BP Key (40-Bit/10-Char Hex Value)\n");
   printf ("\n");
   exit (0);
 }
@@ -854,7 +874,7 @@ main (int argc, char **argv)
   exitflag = 0;
   signal (SIGINT, sigfun);
 
-  while ((c = getopt (argc, argv, "haep:P:qstv:z:i:o:d:c:g:nw:B:C:R:f:m:u:x:A:S:M:G:D:L:V:U:Y:K:NQWrlZTF")) != -1)
+  while ((c = getopt (argc, argv, "haep:P:qstv:z:i:o:d:c:g:nw:B:C:R:f:m:u:x:A:S:M:G:D:L:V:U:Y:K:H:NQWrlZTF")) != -1)
     {
       opterr = 0;
       switch (c)
@@ -927,6 +947,21 @@ main (int argc, char **argv)
           opts.dmr_mute_encL = 0;
           opts.dmr_mute_encR = 0;
           if (state.K == 0)
+          {
+            opts.dmr_mute_encL = 1;
+            opts.dmr_mute_encR = 1;
+          }
+          break;
+
+        case 'H':
+          sscanf (optarg, "%llX", &state.H);
+          if (state.H > 0xFFFFFFFFFF)
+          {
+           state.H = 0xFFFFFFFFFF;
+          }
+          opts.dmr_mute_encL = 0;
+          opts.dmr_mute_encR = 0;
+          if (state.H == 0)
           {
             opts.dmr_mute_encL = 1;
             opts.dmr_mute_encR = 1;

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -632,9 +632,9 @@ usage ()
   printf ("                 Use if skipping occurs, but may cause wonky audio due to loss of good sync\n");
   printf ("  -Z            Log MBE/Frame Payloads to console\n");
   printf ("\n");
-  printf ("  -K <dec>      Manually Enter DMRA BP Key (Decimal Value of Key Number)\n");
+  printf ("  -K <dec>      Manually Enter DMRA Privacy Key (Decimal Value of Key Number)\n");
   printf ("\n");
-  printf ("  -H <hex>      Manually Enter Terra 10 BP Key (40-Bit/10-Char Hex Value)\n");
+  printf ("  -H <hex>      Manually Enter 'Tera 10 Privacy Key (40-Bit/10-Char Hex Value)\n");
   printf ("\n");
   exit (0);
 }

--- a/src/dsd_mbe.c
+++ b/src/dsd_mbe.c
@@ -290,7 +290,7 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
         state->errs2R += mbe_eccAmbe3600x2450Data (ambe_fr, ambe_d);
 
 
-        if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x10)
+        if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fidR == 0x10)
         {
           k = Pr[state->K];
           k = ( ((k & 0xFF0F) << 32 ) + (k << 16) + k );

--- a/src/dsd_mbe.c
+++ b/src/dsd_mbe.c
@@ -77,7 +77,7 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
 {
 
   //
-  int BP[256] = {
+  int Pr[256] = {
     0x0000, 0x1F00, 0xE300, 0xFC00, 0x2503, 0x3A03, 0xC603, 0xD903,
     0x4A05, 0x5505, 0xA905, 0xB605, 0x6F06, 0x7006, 0x8C06, 0x9306,
     0x2618, 0x3918, 0xC518, 0xDA18, 0x031B, 0x1C1B, 0xE01B, 0xFF1B,
@@ -230,7 +230,7 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
 
 		    if (state->K > 0 && state->dmr_so & 0x40 && state->payload_keyid == 0 && state->dmr_fid == 0x10)
         {
-          k = BP[state->K];
+          k = Pr[state->K];
           k = ( ((k & 0xFF0F) << 32 ) + (k << 16) + k );
           for (short int j = 0; j < 48; j++) //49
           {
@@ -292,7 +292,7 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
 
         if (state->K > 0 && state->dmr_soR & 0x40 && state->payload_keyidR == 0 && state->dmr_fid == 0x10)
         {
-          k = BP[state->K];
+          k = Pr[state->K];
           k = ( ((k & 0xFF0F) << 32 ) + (k << 16) + k );
           for (short int j = 0; j < 48; j++)
           {

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -1847,7 +1847,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstL == 16 && state->payload_algid == 0 && state->K > 0 && state->dmr_fid == 0x10 && (state->dmr_so & 0xCF) == 0x40)
     {
       attron(COLOR_PAIR(1));
-      printw ("DMRA P Key [%3lld] ", state->K);
+      printw ("DMRA Pr Key [%3lld] ", state->K);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }
@@ -1855,7 +1855,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstL == 16 && state->payload_algid == 0 && state->H > 0 && state->dmr_fid == 0x68 && ((state->dmr_so & 0xCF) == 0x40) )
     {
       attron(COLOR_PAIR(1));
-      printw ("**'Tera P Key [%010llX] ", state->H);
+      printw ("**'Tera Pr Key [%010llX] ", state->H);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -206,7 +206,7 @@ char *choices[] = {
       "Decode NXDN96",
       "Decode X2-TDMA*",
       "Toggle Signal Inversion",
-      "Basic Key Entry", //spacer
+      "Privacy Key Entry", //spacer
       "Reset Call History",
       "Enable Payloads to Console",
       "Disable Payloads to Console",

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -206,7 +206,7 @@ char *choices[] = {
       "Decode NXDN96",
       "Decode X2-TDMA*",
       "Toggle Signal Inversion",
-      "                       ", //spacer
+      "Basic Key Entry", //spacer
       "Reset Call History",
       "Enable Payloads to Console",
       "Disable Payloads to Console",
@@ -310,13 +310,6 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
   if (opts->audio_in_type == 0) //close pulse input if it is the specified input method
   {
     closePulseInput(opts);
-  }
-
-  if (opts->audio_in_type == 3)
-  {
-    //function hangs, figure out why I can't release/stop the dongle
-    //cleanup_rtlsdr_stream(); //close down the rtl dongle
-    //rtlsdr_sighandler();
   }
 
   state->payload_keyid = 0;
@@ -809,27 +802,59 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     {
       state->payload_keyid = 0;
       state->payload_keyidR = 0;
-      state->K = 0;
-
-      entry_win = newwin(6, WIDTH+6, starty+10, startx+10);
+      // state->K = 0;
+      // state->H = 0;
+      short int option = 0;
+      entry_win = newwin(9, WIDTH+6, starty+10, startx+10);
       box (entry_win, 0, 0);
-      mvwprintw(entry_win, 2, 2, " ");
-      mvwprintw(entry_win, 3, 3, " ");
+      mvwprintw(entry_win, 2, 2, "Key Type Selection");
+      mvwprintw(entry_win, 3, 2, " ");
+      mvwprintw(entry_win, 4, 2, "1 - DMRA BP ");
+      mvwprintw(entry_win, 5, 2, "2 - Tera BP ");
+      mvwprintw(entry_win, 6, 3, " ");
       echo();
       refresh();
-      wscanw(entry_win, "%d", &state->K);
+      wscanw(entry_win, "%d", &option);
       noecho();
       opts->dmr_mute_encL = 0;
       opts->dmr_mute_encR = 0;
-      if (state->K > 255)
+      if (option == 1)
       {
-        state->K = 255;
+        entry_win = newwin(6, WIDTH+6, starty+10, startx+10);
+        box (entry_win, 0, 0);
+        mvwprintw(entry_win, 2, 2, "DMRA BP Key Number (DEC):");
+        mvwprintw(entry_win, 3, 3, " ");
+        echo();
+        refresh();
+        wscanw(entry_win, "%lld", &state->K);
+        noecho();
+        if (state->K > 255)
+        {
+          state->K = 255;
+        }
       }
-      if (state->K == 0)
+      if (option == 2)
+      {
+        entry_win = newwin(6, WIDTH+6, starty+10, startx+10);
+        box (entry_win, 0, 0);
+        mvwprintw(entry_win, 2, 2, "**Tera 10 Key Value (HEX):");
+        mvwprintw(entry_win, 3, 3, " ");
+        echo();
+        refresh();
+        wscanw(entry_win, "%llX", &state->H);
+        noecho();
+        if (state->H > 0xFFFFFFFFFF)
+        {
+          state->H = 0xFFFFFFFFFF;
+        }
+      }
+
+      if (state->K == 0 && state->H == 0)
       {
         opts->dmr_mute_encL = 1;
         opts->dmr_mute_encR = 1;
       }
+
       break;
     }
 
@@ -1367,7 +1392,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
 
     }
 
-    if (state->dmrburstR == 16 && state->lastsrcR > 0) //state->currentslot == 1 &&
+    if (state->dmrburstR == 16 && state->lasttgR > 0) //state->currentslot == 1 &&
     {
       tgR = state->lasttgR;
 
@@ -1766,7 +1791,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
       if (state->payload_algid == 0xAA)
       {
         attron(COLOR_PAIR(1));
-        printw(" ADP/RC4");
+        printw(" RC4");
         attron(COLOR_PAIR(3));
       }
       if (state->payload_algid == 0x81)
@@ -1810,7 +1835,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     printw ("\n");
     //printw ("|        | "); //10 spaces
     printw ("| V XTRA | "); //10 spaces
-    //Burger King
+
     if(state->dmrburstL == 16 && state->payload_algid == 0 && (state->dmr_so & 0xCF) == 0x40) //4F or CF mask? & 0xCF currently
     {
       attron(COLOR_PAIR(5));
@@ -1818,14 +1843,24 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
       attroff(COLOR_PAIR(5));
       attron(COLOR_PAIR(3));
     }
-    //Point
-    if(state->dmrburstL == 16 && state->payload_algid == 0 && state->K > 0 && (state->dmr_so & 0xCF) == 0x40)
+
+    if(state->dmrburstL == 16 && state->payload_algid == 0 && state->K > 0 && state->dmr_fid == 0x10 && (state->dmr_so & 0xCF) == 0x40)
     {
       attron(COLOR_PAIR(1));
-      printw ("BPK [%3lld] ", state->K);
+      //printw ("BPK [%3lld] ", state->K);
+      printw ("DMRA BP Key [%3lld] ", state->K);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }
+
+    if(state->dmrburstL == 16 && state->payload_algid == 0 && state->H > 0 && state->dmr_fid == 0x68 && ((state->dmr_so & 0xCF) == 0x40) )
+    {
+      attron(COLOR_PAIR(1));
+      printw ("**Tera BP Key [%010llX] ", state->H);
+      attroff(COLOR_PAIR(1));
+      attron(COLOR_PAIR(3));
+    }
+
     //ALG, KeyID, MI                            //was key_id
     if(state->dmrburstL == 16 && state->payload_algid > 0 && (state->dmr_so & 0xCF) == 0x40)
     {
@@ -1911,7 +1946,6 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     //printw ("|        | "); //12 spaces
     printw ("| V XTRA | "); //10 spaces
 
-    //Burger King 2
     if(state->dmrburstR == 16 && state->payload_algidR == 0 && (state->dmr_soR & 0xCF) == 0x40) //4F or CF mask?
     {
       attron(COLOR_PAIR(5));
@@ -1919,11 +1953,18 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
       attroff(COLOR_PAIR(5));
       attron(COLOR_PAIR(3));
     }
-    //Point 2
-    if(state->dmrburstR == 16 && state->payload_algidR == 0 && state->K > 0 && (state->dmr_soR & 0xCF) == 0x40)
+
+    if(state->dmrburstR == 16 && state->payload_algidR == 0 && state->K > 0 && ((state->dmr_soR & 0xCF) == 0x40) && state->dmr_fidR == 0x10)
     {
       attron(COLOR_PAIR(1));
-      printw ("BPK [%3lld] ", state->K);
+      printw ("DMRA BP Key [%3lld] ", state->K);
+      attroff(COLOR_PAIR(1));
+      attron(COLOR_PAIR(3));
+    }
+    if(state->dmrburstR == 16 && state->payload_algidR == 0 && state->H > 0 && ((state->dmr_soR & 0xCF) == 0x40) && state->dmr_fidR == 0x68)
+    {
+      attron(COLOR_PAIR(1));
+      printw ("**Tera BP Key [%010llX] ", state->H);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -809,8 +809,8 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       box (entry_win, 0, 0);
       mvwprintw(entry_win, 2, 2, "Key Type Selection");
       mvwprintw(entry_win, 3, 2, " ");
-      mvwprintw(entry_win, 4, 2, "1 - DMRA BP ");
-      mvwprintw(entry_win, 5, 2, "2 - Tera BP ");
+      mvwprintw(entry_win, 4, 2, "1 -  DMRA BP ");
+      mvwprintw(entry_win, 5, 2, "2 - Terra BP ");
       mvwprintw(entry_win, 6, 3, " ");
       echo();
       refresh();
@@ -837,7 +837,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       {
         entry_win = newwin(6, WIDTH+6, starty+10, startx+10);
         box (entry_win, 0, 0);
-        mvwprintw(entry_win, 2, 2, "**Tera 10 Key Value (HEX):");
+        mvwprintw(entry_win, 2, 2, "**Terra 10 Key Value (HEX):");
         mvwprintw(entry_win, 3, 3, " ");
         echo();
         refresh();
@@ -1856,7 +1856,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstL == 16 && state->payload_algid == 0 && state->H > 0 && state->dmr_fid == 0x68 && ((state->dmr_so & 0xCF) == 0x40) )
     {
       attron(COLOR_PAIR(1));
-      printw ("**Tera BP Key [%010llX] ", state->H);
+      printw ("**Terra BP Key [%010llX] ", state->H);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }
@@ -1964,7 +1964,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstR == 16 && state->payload_algidR == 0 && state->H > 0 && ((state->dmr_soR & 0xCF) == 0x40) && state->dmr_fidR == 0x68)
     {
       attron(COLOR_PAIR(1));
-      printw ("**Tera BP Key [%010llX] ", state->H);
+      printw ("**Terra BP Key [%010llX] ", state->H);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -809,8 +809,8 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       box (entry_win, 0, 0);
       mvwprintw(entry_win, 2, 2, "Key Type Selection");
       mvwprintw(entry_win, 3, 2, " ");
-      mvwprintw(entry_win, 4, 2, "1 -  DMRA BP ");
-      mvwprintw(entry_win, 5, 2, "2 - Terra BP ");
+      mvwprintw(entry_win, 4, 2, "1 -  DMRA Privacy ");
+      mvwprintw(entry_win, 5, 2, "2 - 'Tera Privacy ");
       mvwprintw(entry_win, 6, 3, " ");
       echo();
       refresh();
@@ -822,7 +822,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       {
         entry_win = newwin(6, WIDTH+6, starty+10, startx+10);
         box (entry_win, 0, 0);
-        mvwprintw(entry_win, 2, 2, "DMRA BP Key Number (DEC):");
+        mvwprintw(entry_win, 2, 2, "DMRA Privacy Key Number (DEC):");
         mvwprintw(entry_win, 3, 3, " ");
         echo();
         refresh();
@@ -837,7 +837,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       {
         entry_win = newwin(6, WIDTH+6, starty+10, startx+10);
         box (entry_win, 0, 0);
-        mvwprintw(entry_win, 2, 2, "**Terra 10 Key Value (HEX):");
+        mvwprintw(entry_win, 2, 2, "'Tera 10 Key Value (HEX):");
         mvwprintw(entry_win, 3, 3, " ");
         echo();
         refresh();
@@ -1839,7 +1839,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstL == 16 && state->payload_algid == 0 && (state->dmr_so & 0xCF) == 0x40) //4F or CF mask? & 0xCF currently
     {
       attron(COLOR_PAIR(5));
-      printw (" **BP** ");
+      printw (" **Pr** ");
       attroff(COLOR_PAIR(5));
       attron(COLOR_PAIR(3));
     }
@@ -1847,8 +1847,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstL == 16 && state->payload_algid == 0 && state->K > 0 && state->dmr_fid == 0x10 && (state->dmr_so & 0xCF) == 0x40)
     {
       attron(COLOR_PAIR(1));
-      //printw ("BPK [%3lld] ", state->K);
-      printw ("DMRA BP Key [%3lld] ", state->K);
+      printw ("DMRA P Key [%3lld] ", state->K);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }
@@ -1856,7 +1855,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstL == 16 && state->payload_algid == 0 && state->H > 0 && state->dmr_fid == 0x68 && ((state->dmr_so & 0xCF) == 0x40) )
     {
       attron(COLOR_PAIR(1));
-      printw ("**Terra BP Key [%010llX] ", state->H);
+      printw ("**'Tera P Key [%010llX] ", state->H);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }
@@ -1949,7 +1948,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstR == 16 && state->payload_algidR == 0 && (state->dmr_soR & 0xCF) == 0x40) //4F or CF mask?
     {
       attron(COLOR_PAIR(5));
-      printw (" **BP** ");
+      printw (" **Pr** ");
       attroff(COLOR_PAIR(5));
       attron(COLOR_PAIR(3));
     }
@@ -1957,14 +1956,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     if(state->dmrburstR == 16 && state->payload_algidR == 0 && state->K > 0 && ((state->dmr_soR & 0xCF) == 0x40) && state->dmr_fidR == 0x10)
     {
       attron(COLOR_PAIR(1));
-      printw ("DMRA BP Key [%3lld] ", state->K);
+      printw ("DMRA Pr Key [%3lld] ", state->K);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }
     if(state->dmrburstR == 16 && state->payload_algidR == 0 && state->H > 0 && ((state->dmr_soR & 0xCF) == 0x40) && state->dmr_fidR == 0x68)
     {
       attron(COLOR_PAIR(1));
-      printw ("**Terra BP Key [%010llX] ", state->H);
+      printw ("**'Tera Pr Key [%010llX] ", state->H);
       attroff(COLOR_PAIR(1));
       attron(COLOR_PAIR(3));
     }

--- a/src/dsd_symbol.c
+++ b/src/dsd_symbol.c
@@ -358,7 +358,7 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
     //use fopen and read in a symbol, check op25 for clues
     if(opts->symbolfile == NULL)
     {
-      fprintf(stderr, "Error Opening File %s\n", opts->symbolfile);
+      fprintf(stderr, "Error Opening File %s\n", opts->audio_in_dev); //double check this
       return(-1);
     }
 


### PR DESCRIPTION
--Easier to use key entry for privacy modes
---Serpen'tera' 10 mode now available
--Slightly improved dmr dibit buffering/inverted dibit buffering
--Tweaks to console and ncurses output regarding FID, SVC, and privacy key values
--fix for RTL optional support (think I have all the ifdef covered now)
--TGT, SRC, FID, SVC, now set on Voice LC Header (not sure why I wasn't before)
--other misc tweaks that I can't recall