### PR TITLE
P2 Console Output Change; Disable YSF Sync

### DIFF
--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -266,6 +266,7 @@ initOpts (dsd_opts * opts)
   opts->frame_dmr = 1;
   opts->frame_dpmr = 0;
   opts->frame_provoice = 0;
+  opts->frame_ysf = 0; //forgot to init this, and Cygwin treated as it was turned on.
   opts->mod_c4fm = 1;
   opts->mod_qpsk = 1;
   opts->mod_gfsk = 0;
@@ -1181,6 +1182,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 1;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
+              opts.frame_ysf = 0;
               opts.pulse_digi_rate_out = 8000;
               opts.pulse_digi_out_channels = 1;
               opts.dmr_stereo = 0;
@@ -1198,6 +1200,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 0;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
+              opts.frame_ysf = 0;
               opts.pulse_digi_rate_out = 8000;
               opts.pulse_digi_out_channels = 1;
               opts.dmr_stereo = 0;
@@ -1217,6 +1220,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 0;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
+              opts.frame_ysf = 0;
               opts.pulse_digi_rate_out = 8000;
               opts.pulse_digi_out_channels = 1;
               opts.dmr_stereo = 0;
@@ -1235,6 +1239,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 0;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 1;
+              opts.frame_ysf = 0;
               state.samplesPerSymbol = 5;
               state.symbolCenter = 2;
               opts.mod_c4fm = 0;
@@ -1260,6 +1265,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 0;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
+              opts.frame_ysf = 0;
               opts.dmr_stereo = 0;
               state.dmr_stereo = 0;
               opts.mod_c4fm = 1;
@@ -1384,6 +1390,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 0;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
+              opts.frame_ysf = 0;
               opts.mod_c4fm = 1;
               opts.mod_qpsk = 0;
               opts.mod_gfsk = 0;
@@ -1406,6 +1413,7 @@ main (int argc, char **argv)
               opts.frame_dmr = 1;
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
+              opts.frame_ysf = 0;
               opts.mod_c4fm = 1;
               opts.mod_qpsk = 0;
               opts.mod_gfsk = 0; //

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -923,6 +923,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 1;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -951,6 +952,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 1;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 0;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 1;
@@ -977,6 +979,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -1007,6 +1010,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -1036,6 +1040,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_nxdn96 = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -1063,6 +1068,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       //opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -1088,6 +1094,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 1;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -1116,6 +1123,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       //opts->unmute_encrypted_p25 = 0;
       // opts->mod_qpsk = 0;
@@ -1141,6 +1149,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;
@@ -1167,6 +1176,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       opts->frame_dmr = 0;
       opts->frame_dpmr = 0;
       opts->frame_provoice = 0;
+      opts->frame_ysf = 0;
       opts->mod_c4fm = 1;
       opts->mod_qpsk = 0;
       opts->mod_gfsk = 0;

--- a/src/p25_p2.c
+++ b/src/p25_p2.c
@@ -261,7 +261,6 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 
 			if (1 == 1) //state->p2_is_lcch == 1
 			{
-				//fprintf (stderr, "%s", KCYN);
 				fprintf (stderr, "\n Secondary Control Channel Broadcast - Explicit\n");
 				fprintf (stderr, "  RFSS[%03d] SITE ID [%03X] CHAN-T [%04X] CHAN-R [%04X] SSC [%02X]", rfssid, siteid, channelt, channelr, sysclass);
 				fprintf (stderr, "%s", KNRM);
@@ -280,7 +279,6 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int sysclass2 = MAC[9+len_a];
 			if (1 == 1) //state->p2_is_lcch == 1
 			{
-				//fprintf (stderr, "%s", KCYN);
 				fprintf (stderr, "\n Secondary Control Channel Broadcast - Implicit\n");
 				fprintf (stderr, "  RFSS[%03d] SITE ID [%03X] CHAN1 [%04X] SSC [%02X] CHAN2 [%04X] SSC [%02X]", rfssid, siteid, channel1, sysclass1, channel2, sysclass2);
 				fprintf (stderr, "%s", KNRM);
@@ -733,6 +731,7 @@ void process_SACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[180]
 	{
 		if (state->currentslot == 1) state->dmrburstL = 24;
 		else state->dmrburstR = 24;
+		fprintf (stderr, "%s", KMAG);
 		fprintf (stderr, " MAC_IDLE ");
 		process_MAC_VPDU(opts, state, 1, SMAC);
 		fprintf (stderr, "%s", KNRM);
@@ -742,7 +741,7 @@ void process_SACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[180]
 		if (state->currentslot == 1) state->dmrburstL = 21;
 		else state->dmrburstR = 21;
 		fprintf (stderr, " MAC_ACTIVE ");
-		fprintf (stderr, "%s", KGRN);
+		fprintf (stderr, "%s", KMAG);
 		process_MAC_VPDU(opts, state, 1, SMAC);
 		fprintf (stderr, "%s", KNRM);
 	}
@@ -751,7 +750,7 @@ void process_SACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[180]
 		if (state->currentslot == 1) state->dmrburstL = 22;
 		else state->dmrburstR = 22;
 		fprintf (stderr, " MAC_HANGTIME ");
-		fprintf (stderr, "%s", KYEL);
+		fprintf (stderr, "%s", KMAG);
 		process_MAC_VPDU(opts, state, 1, SMAC);
 		fprintf (stderr, "%s", KNRM);
 	}
@@ -965,6 +964,7 @@ void process_FACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[156]
 
 		}
 		fprintf (stderr, " MAC_IDLE ");
+		fprintf (stderr, "%s", KMAG);
 		process_MAC_VPDU(opts, state, 0, FMAC);
 		fprintf (stderr, "%s", KNRM);
 	}
@@ -973,7 +973,7 @@ void process_FACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[156]
 		if (state->currentslot == 0) state->dmrburstL = 21;
 		else state->dmrburstR = 21;
 		fprintf (stderr, " MAC_ACTIVE ");
-		fprintf (stderr, "%s", KGRN);
+		fprintf (stderr, "%s", KMAG);
 		process_MAC_VPDU(opts, state, 0, FMAC);
 		fprintf (stderr, "%s", KNRM);
 	}
@@ -982,7 +982,7 @@ void process_FACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[156]
 		if (state->currentslot == 0) state->dmrburstL = 22;
 		else state->dmrburstR = 22;
 		fprintf (stderr, " MAC_HANGTIME ");
-		fprintf (stderr, "%s", KYEL);
+		fprintf (stderr, "%s", KMAG);
 		process_MAC_VPDU(opts, state, 0, FMAC);
 		fprintf (stderr, "%s", KNRM);
 	}


### PR DESCRIPTION
P2 Console Output Change; 
--change up color coding slightly
Disable YSF Sync
--frame_ysf variable was never initialized, so some systems would false sync on YSF (YSF never finished, no handling yet)