### PR TITLE
fixed function signature

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -873,7 +873,7 @@ void ProcessReservedData(dsd_opts * opts, dsd_state * state, uint8_t info[196], 
 void ProcessUnifiedData(dsd_opts * opts, dsd_state * state, uint8_t info[196], uint8_t syncdata[48], uint8_t SlotType[20]);
 
 //LFSR code courtesy of https://github.com/mattames/LFSR/
-int LFSR(dsd_state * state);
+void LFSR(dsd_state * state);
 void LFSRN (char * BufferIn, char * BufferOut, dsd_state * state);
 
 void Hamming_7_4_init();

--- a/src/dmr_sync.c
+++ b/src/dmr_sync.c
@@ -2747,7 +2747,7 @@ void ProcessVoiceBurstSync(dsd_opts * opts, dsd_state * state)
 } /* End ProcessVoiceBurstSync() */
 
 //LFSR code courtesy of https://github.com/mattames/LFSR/
-int LFSR(dsd_state * state)
+void LFSR(dsd_state * state)
 {
 
   int lfsr = 0;


### PR DESCRIPTION
There is no return value in the implementation of LFSR function, and also in the code I did not find that it was used somewhere. So I replaced int return type to void. 

It's not a problem, but a small correction. Thanks.