### PR TITLE
Add signal handlers for a proper cleanup

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -1130,7 +1130,7 @@ extern "C" {
 #ifdef USE_RTLSDR
 void open_rtlsdr_stream(dsd_opts *opts);
 void cleanup_rtlsdr_stream();
-void get_rtlsdr_sample(int16_t *sample, dsd_opts * opts, dsd_state * state);
+int get_rtlsdr_sample(int16_t *sample, dsd_opts * opts, dsd_state * state);
 void rtlsdr_sighandler();
 void rtl_dev_tune(dsd_opts * opts, long int frequency);
 int rtl_return_rms();

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -1732,8 +1732,6 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     }
     if (choice == 20)
     {
-      ncursesClose();
-      //cleanup_rtlsdr_stream();
       cleanupAndExit (opts, state);
     }
 
@@ -3414,7 +3412,6 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
 
   if (c == 113) //'q' key, quit
   {
-    ncursesClose();
     cleanupAndExit (opts, state);
   }
 

--- a/src/dsd_symbol.c
+++ b/src/dsd_symbol.c
@@ -121,7 +121,6 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
           //else cleanup and exit
           else
           {
-            if (opts->use_ncurses_terminal == 1) ncursesClose(opts);
             cleanupAndExit(opts, state);     
           }        
         }
@@ -131,7 +130,10 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
 #ifdef USE_RTLSDR
         // TODO: need to read demodulated stream here
         // get_rtlsdr_sample(&sample);
-        get_rtlsdr_sample(&sample, opts, state);
+        if (get_rtlsdr_sample(&sample, opts, state) < 0)
+        {
+          cleanupAndExit(opts, state);
+        }
         if (opts->monitor_input_audio == 1 && state->lastsynctype == -1 && sample < 32767 && sample > -32767)
         {
           state->pulse_raw_out_buffer = sample; //steal raw out buffer sample here?
@@ -195,7 +197,6 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
             {
               fprintf (stderr, "Connection to TCP Server Disconnected.\n");
               fprintf (stderr, "Closing DSD-FME.\n");
-              if (opts->use_ncurses_terminal == 1) ncursesClose(opts);
               cleanupAndExit(opts, state);
             }
             
@@ -533,7 +534,6 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
       //else cleanup and exit
       else
       {
-        if (opts->use_ncurses_terminal == 1) ncursesClose(opts);
         cleanupAndExit(opts, state);
       }
     }


### PR DESCRIPTION
The code is mostly trivial. The only troublesome part is in get_rtlsdr_sample. I removed the unconditional wait and regularly check if exitflag has changed instead.