### PR TITLE
Fix unused variable warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 ADD_EXECUTABLE(dsd-fme ${SRCS} ${HEADERS})
 TARGET_LINK_LIBRARIES(dsd-fme ${LIBS})
 
+target_compile_options(dsd-fme PRIVATE -Wunused-but-set-variable -Wunused-variable)
+
 include(GNUInstallDirs)
 install(TARGETS dsd-fme DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/include/dsd.h
+++ b/include/dsd.h
@@ -74,7 +74,7 @@
 #include <locale.h>
 #include <ncurses.h>
 
-static volatile int exitflag;
+extern volatile uint8_t exitflag; //fix for issue #136
 
 //group csv import struct
 typedef struct

--- a/include/dsd.h
+++ b/include/dsd.h
@@ -74,6 +74,12 @@
 #include <locale.h>
 #include <ncurses.h>
 
+#define UNUSED(x)                       ((void)x)
+#define UNUSED2(x1, x2)                 (UNUSED(x1), UNUSED(x2))
+#define UNUSED3(x1, x2, x3)             (UNUSED(x1), UNUSED(x2), UNUSED(x3))
+#define UNUSED4(x1, x2, x3, x4)         (UNUSED(x1), UNUSED(x2), UNUSED(x3), UNUSED(x4))
+#define UNUSED5(x1, x2, x3, x4, x5)     (UNUSED(x1), UNUSED(x2), UNUSED(x3), UNUSED(x4), UNUSED(x5))
+
 extern volatile uint8_t exitflag; //fix for issue #136
 
 //group csv import struct
@@ -921,12 +927,12 @@ void nxdn_message_type (dsd_opts * opts, dsd_state * state, uint8_t MessageType)
 void nxdn_voice (dsd_opts * opts, dsd_state * state, int voice, uint8_t dbuf[182]);
 
 //OP25 NXDN CRC functions
-static inline int load_i(const uint8_t val[], int len);
-static uint8_t crc6(const uint8_t buf[], int len);
-static uint16_t crc12f(const uint8_t buf[], int len);
-static uint16_t crc15(const uint8_t buf[], int len);
-static uint16_t crc16cac(const uint8_t buf[], int len);
-static uint8_t crc7_scch(uint8_t bits[], int len); //converted from op25 crc6
+int load_i(const uint8_t val[], int len);
+uint8_t crc6(const uint8_t buf[], int len);
+uint16_t crc12f(const uint8_t buf[], int len);
+uint16_t crc15(const uint8_t buf[], int len);
+uint16_t crc16cac(const uint8_t buf[], int len);
+uint8_t crc7_scch(uint8_t bits[], int len); //converted from op25 crc6
 
 /* NXDN Convolution functions */
 void CNXDNConvolution_start(void);

--- a/include/dsd.h
+++ b/include/dsd.h
@@ -705,6 +705,20 @@ typedef struct
   //Upsampled Audio Smoothing
   uint8_t audio_smoothing;
 
+  //YSF Fusion Call Strings and Info
+  uint8_t ysf_dt; //data type -- VD1, VD2, Full Rate, etc.
+  uint8_t ysf_fi; //frame information -- HC, CC, TC
+  uint8_t ysf_cm; //group or private call
+  char ysf_tgt[11];
+  char ysf_src[11];
+  char ysf_upl[11];
+  char ysf_dnl[11];
+  char ysf_rm1[6];
+  char ysf_rm2[6];
+  char ysf_rm3[6];
+  char ysf_rm4[6];
+  char ysf_txt[21][21]; //text storage blocks
+
 } dsd_state;
 
 /*

--- a/src/dmr_block.c
+++ b/src/dmr_block.c
@@ -12,7 +12,7 @@
 void dmr_dheader (dsd_opts * opts, dsd_state * state, uint8_t dheader[], uint8_t dheader_bits[], uint32_t CRCCorrect, uint32_t IrrecoverableErrors)
 {
   
-  uint32_t i, j, k;
+  uint32_t i;
   uint8_t slot = state->currentslot;
 
   //clear out unified pdu 'superframe' slot
@@ -30,7 +30,8 @@ void dmr_dheader (dsd_opts * opts, dsd_state * state, uint8_t dheader[], uint8_t
     uint8_t dpf = (uint8_t)ConvertBitIntoBytes(&dheader_bits[4], 4); //data packet format
     uint8_t sap = (uint8_t)ConvertBitIntoBytes(&dheader_bits[8], 4); //service access point
     uint8_t poc = (uint8_t)ConvertBitIntoBytes(&dheader_bits[8], 4); //padding octets
-    
+    UNUSED(ab);
+
     uint32_t target = (uint32_t)ConvertBitIntoBytes(&dheader_bits[16], 24); //destination llid 
     uint32_t source = (uint32_t)ConvertBitIntoBytes(&dheader_bits[40], 24); //source llid
 
@@ -121,6 +122,7 @@ void dmr_dheader (dsd_opts * opts, dsd_state * state, uint8_t dheader[], uint8_t
     uint8_t p_sap  = (uint8_t)ConvertBitIntoBytes(&dheader_bits[0], 4);
     uint8_t p_mfid = (uint8_t)ConvertBitIntoBytes(&dheader_bits[8], 8);
     uint8_t p_pot  = (uint8_t)ConvertBitIntoBytes(&dheader_bits[3], 5); //looking for LRRP pot_report
+    UNUSED(p_pot);
 
     fprintf (stderr, "%s ", KGRN);
     fprintf (stderr, "\n");
@@ -379,6 +381,7 @@ void dmr_udt_cspdu_converter (dsd_opts * opts, dsd_state * state, uint8_t block_
   uint8_t udt_opcode = (uint8_t)ConvertBitIntoBytes(&block_bits[74], 6); //for observation testing
   cs_byte[1] = 0; //set mfid to zero for now (may use custom value if needed later)
   uint8_t udt_mfid = 0; //setting to zero
+  UNUSED2(udt_opcode, udt_mfid);
 
   //should be 34 total (maximum) after removing tailing CRC16 (initial and last block)
   for (i = 0; i < 34; i++) cs_byte[2+i] = block_bytes[12+i];
@@ -403,7 +406,7 @@ void dmr_udt_cspdu_converter (dsd_opts * opts, dsd_state * state, uint8_t block_
 //assemble the blocks as they come in, shuffle them into the unified dmr_pdu_sf
 void dmr_block_assembler (dsd_opts * opts, dsd_state * state, uint8_t block_bytes[], uint8_t block_len, uint8_t databurst, uint8_t type)
 {
-  int i, j, k;
+  int i, j;
   uint8_t lb = 0; //mbc last block
   uint8_t pf = 0; //mbc protect flag
 

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -13,8 +13,7 @@
 //processing voice and/or data on both BS slots (channels) simultaneously
 void dmrBS (dsd_opts * opts, dsd_state * state)
 {
-  int i, j, k, l, dibit;
-  int *dibit_p;
+  int i, dibit;
   
   char ambe_fr[4][24];
   char ambe_fr2[4][24];
@@ -37,6 +36,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
   uint8_t emb_ok = 0;
   uint8_t tact_okay = 0;
   uint8_t cach_err = 0;
+  UNUSED(cach_err);
 
   uint8_t internalslot;
   uint8_t vc1;
@@ -46,13 +46,13 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
   uint8_t cc = 25;
   uint8_t power = 9; //power and pre-emption indicator
   uint8_t lcss = 9;
+  UNUSED2(cc, lcss);
   
   //would be ideal to grab all dibits and break them into bits to pass to new data handler?
   uint8_t dummy_bits[196]; 
   memset (dummy_bits, 0, sizeof(dummy_bits));
   
   //add time to mirror printFrameSync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);
@@ -492,7 +492,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
 //Process buffered half frame and 2nd half and then jump to full BS decoding
 void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
 {
-  int i, j, k, l, dibit;
+  int i, dibit;
   int *dibit_p;
   char ambe_fr[4][24];
   char ambe_fr2[4][24];
@@ -512,6 +512,7 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
   uint8_t tact_okay = 0;
   uint8_t cach_err = 0;
   uint8_t sync_okay = 1;
+  UNUSED(cach_err);
 
   uint8_t internalslot;
 
@@ -523,7 +524,6 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
   19, 5, 20, 21, 22, 6, 23
   }; 
   //add time to mirror printFrameSync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);

--- a/src/dmr_csbk.c
+++ b/src/dmr_csbk.c
@@ -29,6 +29,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
   csbk_pf  = ( (cs_pdu[0] & 0x40) >> 6 );
   csbk_o   =    cs_pdu[0] & 0x3F; 
   csbk_fid =    cs_pdu[1]; //feature set id
+  UNUSED(csbk_lb);
 
   //check, regardless of CRC err
   if (IrrecoverableErrors == 0)
@@ -103,6 +104,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         //target and source are always the same bits
         uint32_t target = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[32], 24);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[56], 24);
+        UNUSED2(st1, st3);
 
         //move mbc variables out of if statement
         uint8_t mbc_lb = 0; //
@@ -118,6 +120,8 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint16_t mbc_abs_tx_step = 0;
         uint16_t mbc_abs_rx_int = 0;
         uint16_t mbc_abs_rx_step = 0;
+        UNUSED5(mbc_lb, mbc_pf, mbc_csbko, mbc_res, mbc_cc);
+        UNUSED4(mbc_res2, mbc_cdefparms, mbc_abs_tx_int, mbc_abs_tx_step);
 
         fprintf (stderr, "\n");
         //added my best guess as to how dsdplus arrives at a dmr channel value (seems pretty consistent) as C+
@@ -294,14 +298,14 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t nrandwait = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[31], 4);
         uint8_t regreq = cs_pdu_bits[35];
         uint8_t backoff = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[36], 4);
+        UNUSED5(reserved, tsccas, sync, offset, active);
+        UNUSED3(sf, nrandwait, backoff);
 
         uint8_t model = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[40], 2);
         uint16_t net = 0;
         uint16_t site = 0;
 
         //DMR Location Area - DMRLA
-        uint16_t sys_area = 0;
-        uint16_t sub_area = 0;
         uint16_t sub_mask = 0x1;
         //tiny n 1-3; small 1-5; large 1-8; huge 1-10
         uint16_t n = 1; //The minimum value of DMRLA is normally ≥ 1, 0 is reserved
@@ -406,6 +410,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         //fprintf (stderr, "\n  SYSCODE: %016b", syscode);
         //fprintf (stderr, "\n  SYSCODE: %02b.%b.%b", model, net, site); //won't show leading zeroes, but may not be required
         //fprintf (stderr, "\n  SYSCODE: %04X", syscode);
+        UNUSED(syscode);
       } 
 
       //P_CLEAR
@@ -427,6 +432,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t gi = cs_pdu_bits[31];
         uint32_t target = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[32], 24);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[56], 24);
+        UNUSED(reserved);
 
         if (gi)  fprintf (stderr, " Group");
         if (!gi) fprintf (stderr, " Private");
@@ -462,16 +468,17 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t model = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[40], 2);
         uint16_t net = 0;
         uint16_t site = 0;
+        UNUSED2(net, site);
 
         //DMR Location Area - DMRLA
-        uint16_t sys_area = 0;
-        uint16_t sub_area = 0;
         uint16_t sub_mask = 0x1;
         //tiny n 1-3; small 1-5; large 1-8; huge 1-10
         uint16_t n = 1; //The minimum value of DMRLA is normally ≥ 1, 0 is reserved
+        UNUSED(sub_mask);
 
         //channel number from Broadcast Parms 2
         uint16_t lpchannum = 0;
+        UNUSED(lpchannum);
 
         char model_str[8];
         char par_str[8]; //category A, B, AB, or reserved
@@ -561,7 +568,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint16_t syscode = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[40], 16);
         //fprintf (stderr, "\n  SYSCODE: %016b", syscode);
         //fprintf (stderr, "\n  SYSCODE: %04X", syscode);
-
+        UNUSED(syscode);
       }
 
       if (csbk_o == 28) 
@@ -651,6 +658,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t blocks = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[24], 8);
         uint32_t target = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[32], 24);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[56], 24);
+        UNUSED2(res, blocks);
 
         uint8_t target_hash[24]; 
         uint8_t tg_hash = 0; 
@@ -1453,6 +1461,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t xpt_site_rp[4];
         uint8_t xpt_site_u1[4];
         uint8_t xpt_site_u2[4];
+        UNUSED2(xpt_site_u1, xpt_site_u2);
 
         uint8_t xpt_sn = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[0], 2); 
 

--- a/src/dmr_data.c
+++ b/src/dmr_data.c
@@ -26,13 +26,14 @@ dmr_data_sync (dsd_opts * opts, dsd_state * state)
   char sync[25];
   char syncdata[48];
   char cachdata[25];
+  UNUSED(syncdata);
 
-  char bursttype[5];
   uint8_t burst;
   char info[196];
   unsigned char SlotType[20]; 
   unsigned int SlotTypeOk;
   uint8_t cach_err = 0;
+  UNUSED(cach_err);
 
   int cachInterleave[24] = 
   {0, 7, 8, 9, 1, 10,

--- a/src/dmr_dburst.c
+++ b/src/dmr_dburst.c
@@ -26,13 +26,13 @@ void dmr_data_burst_handler(dsd_opts * opts, dsd_state * state, uint8_t info[196
   uint32_t CRCCorrect       = 0;
   uint32_t IrrecoverableErrors = 0;
   uint8_t slot = state->currentslot;
-  uint8_t block = state->data_block_counter[slot];
 
   //confirmed data 
   uint8_t dbsn = 0; //data block serial number for confirmed data blocks
   uint8_t blockcounter = 0; //local block count
   uint8_t confdatabits[250]; //array to reshuffle conf data block bits into sequence for crc9 check
   memset (confdatabits, 0, sizeof(confdatabits));
+  UNUSED(dbsn);
 
   //BPTC 196x96 Specific
   uint8_t  BPTCDeInteleavedData[196];

--- a/src/dmr_flco.c
+++ b/src/dmr_flco.c
@@ -30,6 +30,7 @@ void dmr_flco (dsd_opts * opts, dsd_state * state, uint8_t lc_bits[], uint32_t C
   int is_cap_plus = 0;
   int is_alias = 0;
   int is_gps = 0;
+  UNUSED(capsite);
 
   //XPT 'Things'
   int is_xpt = 0;
@@ -41,6 +42,7 @@ void dmr_flco (dsd_opts * opts, dsd_state * state, uint8_t lc_bits[], uint32_t C
   uint8_t xpt_res_c = 0; //unknown values of other bits of the XPT LC
   uint8_t target_hash[24]; //for XPT (and others if desired, get the hash and compare against SLC or XPT Status CSBKs)
   uint8_t tg_hash = 0; //value of the hashed TG
+  UNUSED3(xpt_res_a, xpt_res_b, xpt_res_c);
 
   uint8_t slot = state->currentslot;
   uint8_t unk = 0; //flag for unknown FLCO + FID combo
@@ -590,7 +592,7 @@ uint8_t dmr_cach (dsd_opts * opts, dsd_state * state, uint8_t cach_bits[25])
   int i, j;
   uint8_t err = 0;
   uint8_t tact_valid = 0; 
-  uint8_t cach_valid = 0;
+  UNUSED(tact_valid);
 
   bool h1, h2, h3, crc; 
 
@@ -603,6 +605,7 @@ uint8_t dmr_cach (dsd_opts * opts, dsd_state * state, uint8_t cach_bits[25])
   uint8_t at = 0; //access type, set to 1 during continuous transmission mode 
   uint8_t slot = 2; //tdma time slot
   uint8_t lcss = 0; //link control start stop (9.3.3) NOTE: There is no Single fragment LC defined for CACH signalling
+  UNUSED2(at, slot);
 
   //cach_bits are already de-interleaved upon initial collection (still needs secodary slco de-interleave)
   for (i = 0; i < 7; i++)
@@ -764,6 +767,8 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
   uint16_t netsite = (uint16_t)ConvertBitIntoBytes(&slco_bits[6], 12);
   uint8_t reg = slco_bits[18]; //registration required/not required or normalchanneltype/composite cch
   uint8_t csc = (uint16_t)ConvertBitIntoBytes(&slco_bits[19], 9); //common slot counter, 0-511
+  UNUSED(netsite);
+
   uint16_t net = 0;
 	uint16_t site = 0;
   char model_str[8];
@@ -775,8 +780,6 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
   uint8_t ts2_hash = (uint8_t)ConvertBitIntoBytes(&slco_bits[20], 8); //ts2 address hash (crc8) //361-1 B.3.7
 
   //DMR Location Area - DMRLA - should probably be state variables so we can use this in both slc and csbk
-  uint16_t sys_area = 0;
-  uint16_t sub_area = 0;
   uint16_t sub_mask = 0x1;
   //tiny n 1-3; small 1-5; large 1-8; huge 1-10
   uint16_t n = 1; //The minimum value of DMRLA is normally ≥ 1, 0 is reserved
@@ -871,7 +874,7 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
     uint16_t syscode = (uint16_t)ConvertBitIntoBytes(&slco_bits[4], 14);
     //fprintf (stderr, "\n  SYSCODE: %014b", syscode);
     //fprintf (stderr, "\n  SYSCODE: %02b.%b.%b", model, net, site); //won't show leading zeroes, but may not be required
-
+    UNUSED(syscode);
   }
   else if (slco == 0x3) //P_SYS_Parms
   {
@@ -886,7 +889,7 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
     uint16_t syscode = (uint16_t)ConvertBitIntoBytes(&slco_bits[4], 14);
     //fprintf (stderr, "\n  SYSCODE: %014b", syscode);
     //fprintf (stderr, "\n  SYSCODE: %02b.%b.%b", model, net, site); //won't show leading zeroes, but may not be required
-
+    UNUSED(syscode);
   }
   else if (slco == 0x0) //null
     fprintf (stderr, " SLCO NULL ");
@@ -954,8 +957,6 @@ void dmr_embedded_alias_header (dsd_opts * opts, dsd_state * state, uint8_t lc_b
 {
   
   uint8_t slot = state->currentslot;
-  uint8_t pf; 
-  uint8_t res;
   uint8_t format = (uint8_t)ConvertBitIntoBytes(&lc_bits[16], 2); 
   uint8_t len;
 
@@ -982,6 +983,7 @@ void dmr_embedded_alias_blocks (dsd_opts * opts, dsd_state * state, uint8_t lc_b
   uint8_t format = state->dmr_alias_format[slot]; //0=7-bit; 1=ISO8; 2=UTF-8; 3=UTF16BE
   uint8_t len =  state->dmr_alias_len[slot];
   uint8_t start; //starting position depends on context of block and format
+  UNUSED(format);
 
   //Cap Max Variation
   uint8_t fid = (uint8_t)ConvertBitIntoBytes(&lc_bits[8], 8);
@@ -1049,6 +1051,7 @@ void dmr_embedded_gps (dsd_opts * opts, dsd_state * state, uint8_t lc_bits[])
   uint8_t res_a = lc_bits[1];
   uint8_t res_b = (uint8_t)ConvertBitIntoBytes(&lc_bits[16], 4);
   uint8_t pos_err = (uint8_t)ConvertBitIntoBytes(&lc_bits[20], 3);
+  UNUSED2(res_a, res_b);
   
   uint32_t lon_sign = lc_bits[23]; 
   uint32_t lon = (uint32_t)ConvertBitIntoBytes(&lc_bits[24], 24); 

--- a/src/dmr_le.c
+++ b/src/dmr_le.c
@@ -189,6 +189,7 @@ void dmr_sbrc (dsd_opts * opts, dsd_state * state, uint8_t power)
   uint8_t crc7_okay = 0; //RC
   uint8_t crc3_okay = 0; //TXI
   uint8_t txi = 0; //SEE: https://patents.google.com/patent/US8271009B2
+  UNUSED(txi);
   
   //NOTE: Any previous mentions to Cap+ in this area may have been in error,
   //The signalling observed here was actually TXI information, not Cap+ Specifically

--- a/src/dmr_ms.c
+++ b/src/dmr_ms.c
@@ -13,8 +13,7 @@
 void dmrMS (dsd_opts * opts, dsd_state * state)
 {
 
-  int i, j, k, l, dibit;
-  int *dibit_p;
+  int i, j, dibit;
   char ambe_fr[4][24];
   char ambe_fr2[4][24];
   char ambe_fr3[4][24];
@@ -32,20 +31,13 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
 
   //cach
   char cachdata[25]; 
-  int cachInterleave[24] =
-  {0, 7, 8, 9, 1, 10,
-   11, 12, 2, 13, 14,
-   15, 3, 16, 4, 17, 18,
-   19, 5, 20, 21, 22, 6, 23
-  }; 
 
   //cach tact bits
   uint8_t tact_bits[7];
 
-  uint8_t emb_ok = 0;
   uint8_t tact_okay = 0;
-  uint8_t cach_err = 0;
   uint8_t EmbeddedSignallingOk = 0;
+  UNUSED(EmbeddedSignallingOk);
 
   uint8_t internalslot;
   uint8_t vc;
@@ -54,13 +46,13 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
   uint8_t cc = 25;
   uint8_t power = 9; //power and pre-emption indicator
   uint8_t lcss = 9;
+  UNUSED2(cc, lcss);
 
   //dummy bits to pass to dburst for link control
   uint8_t dummy_bits[196];
   memset (dummy_bits, 0, sizeof (dummy_bits));
 
   //add time to mirror printFrameSync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);
@@ -77,8 +69,6 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
   }
 
   vc = 2;
-
-  short int skipcount = 0;
 
   //Hardset variables for MS/Mono
   state->currentslot = 0; //0
@@ -368,7 +358,7 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
 //collect buffered 1st half and get 2nd half voice payload and then jump to full MS Voice decoding.
 void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
 {
-  int i, j, k, l, dibit;
+  int i, dibit;
   int *dibit_p;
 
   char ambe_fr[4][24];
@@ -386,30 +376,12 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
   char m3[4][24];
 
   const int *w, *x, *y, *z;
-  char sync[25];
-  char syncdata[48];
 
   //cach
   char cachdata[25]; 
-  int cachInterleave[24] =
-  {0, 7, 8, 9, 1, 10,
-   11, 12, 2, 13, 14,
-   15, 3, 16, 4, 17, 18,
-   19, 5, 20, 21, 22, 6, 23
-  };
-
-  int mutecurrentslot;
-  int msMode;
-  char cc[4];
-  char EmbeddedSignalling[16];
-
-  uint8_t emb_ok = 0;
-  uint8_t tact_okay = 0;
-  uint8_t cach_err = 0;
-  uint8_t EmbeddedSignallingOk = 0;
+  UNUSED(cachdata);
 
   //add time to mirror sync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);
@@ -609,12 +581,11 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
 //simplied to a simple data collector, and then passed on to dmr_data_sync for the usual processing
 void dmrMSData (dsd_opts * opts, dsd_state * state)
 {
-  int i, b, c;
+  int i;
   int dibit;
   int *dibit_p;
 
   //add time to mirror sync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);

--- a/src/dmr_pdu.c
+++ b/src/dmr_pdu.c
@@ -38,11 +38,7 @@ char * getDateL(void) {
 void dmr_pdu (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR_PDU[])
 {
 
-  uint8_t message_len = 0;
   uint8_t slot = state->currentslot;
-  uint8_t blocks  = state->data_header_blocks[slot]; 
-  uint8_t padding = state->data_header_padding[slot];
-  uint8_t lrrp_conf = 0;
 
   //check for more available flag info, etc on these prior to running
   if (DMR_PDU[0] == 0x01) dmr_locn (opts, state, block_len, DMR_PDU);
@@ -59,7 +55,7 @@ void dmr_pdu (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR
 //this is by no means an extensive LRRP list and is prone to error (unless somebody has the manual or something)
 void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR_PDU[])
 {
-  int i, j;
+  int i;
   uint16_t message_len = 0;
   uint8_t slot = state->currentslot;
   uint8_t blocks = state->data_header_blocks[slot];
@@ -96,6 +92,7 @@ void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
   uint16_t vel = 0;
   double velocity = 0;
   uint8_t vel_set = 0;
+  UNUSED(vel);
 
   //track, direction, degrees
   uint8_t degrees = 0;
@@ -417,7 +414,7 @@ void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
 
 void dmr_locn (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR_PDU[])
 {
-  int i, j;
+  int i;
   uint8_t slot = state->currentslot;
   uint8_t blocks = state->data_header_blocks[slot];
   uint8_t padding = state->data_header_padding[slot];
@@ -467,8 +464,7 @@ void dmr_locn (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
   //N is positive, E is positive?? Assuming its like a 2D plane
   int lat_sign = 1; //positive 1 or negative 1
   int lon_sign = 1; //positive 1 or negative 1
-  double lat_fin = 0;
-  double lon_fin = 0;
+  UNUSED2(lat_sign, lon_sign);
 
   //start looking for specific bytes corresponding to 'letters' A (time), NSEW (ordinal directions), etc
   for (i = 0; i < ( (blocks*block_len) - (padding+4) ); i++)

--- a/src/dpmr_voice.c
+++ b/src/dpmr_voice.c
@@ -53,15 +53,10 @@ void processdPMRvoice (dsd_opts * opts, dsd_state * state)
   uint32_t CCH_EmergencyPriority[NB_OF_DPMR_VOICE_FRAME_TO_DECODE];
   uint32_t CCH_Reserved[NB_OF_DPMR_VOICE_FRAME_TO_DECODE];
   uint32_t CCH_SlowData[NB_OF_DPMR_VOICE_FRAME_TO_DECODE];
-  uint32_t *errs;
-  uint32_t *errs2;
-  uint8_t AmbeBitDescrambled[49] = {0};
-  uint32_t ScramblerKey = 0;
   uint32_t PartOfSuperFrame = 0;
-  uint32_t VoiceFrameFlag = 1; /* We consider the current frame as a voice frame */
-  uint32_t AttachedDataFlag = 0;
   uint8_t CalledID[8] = {0};
   uint8_t CallingID[8] = {0};
+  UNUSED(PartOfSuperFrame);
 
   /* First CCH (Control CHannel) - 72 bit */
   k = 0;

--- a/src/dsd_audio.c
+++ b/src/dsd_audio.c
@@ -423,10 +423,7 @@ void writeSynthesizedVoiceR (dsd_opts * opts, dsd_state * state)
 
 void writeRawSample (dsd_opts * opts, dsd_state * state, short sample)
 {
-  int n;
-  short aout_buf[160];
-  short *aout_buf_p;
-
+  //short aout_buf[160];
   //sf_write_short(opts->wav_out_raw, aout_buf, 160);
 
   //only write if actual audio, truncate silence
@@ -441,6 +438,7 @@ void
 playSynthesizedVoice (dsd_opts * opts, dsd_state * state)
 {
   ssize_t result;
+  UNUSED(result);
 
   if (state->audio_out_idx > opts->delay)
   {
@@ -475,6 +473,7 @@ void
 playSynthesizedVoiceR (dsd_opts * opts, dsd_state * state)
 {
   ssize_t result;
+  UNUSED(result);
 
   if (state->audio_out_idxR > opts->delay)
   {
@@ -521,7 +520,7 @@ openAudioOutDevice (dsd_opts * opts, int speed)
   }
 	else
 	{
-		struct stat stat_buf;
+  // struct stat stat_buf;
   // if(stat(opts->audio_out_dev, &stat_buf) != 0 && strncmp(opts->audio_out_dev, "pulse", 5 != 0)) //HERE
   //   {
   //     fprintf (stderr,"Error, couldn't open %s\n", opts->audio_out_dev);

--- a/src/dsd_dibit.c
+++ b/src/dsd_dibit.c
@@ -483,6 +483,7 @@ skipDibit (dsd_opts * opts, dsd_state * state, int count)
 
   short sample;
   int i;
+  UNUSED(sample);
 
   for (i = 0; i < (count); i++)
     {

--- a/src/dsd_dibit.c
+++ b/src/dsd_dibit.c
@@ -264,18 +264,18 @@ static int digitize (dsd_opts* opts, dsd_state* state, int symbol)
     }
 
   else if ((state->synctype == 1) || (state->synctype == 3)  || (state->synctype == 5)  ||
-          (state->synctype == 9)  || (state->synctype == 11) || (state->synctype == 13) ||
+          (state->synctype == 31) || (state->synctype == 11) || (state->synctype == 13) ||
           (state->synctype == 17) || (state->synctype == 29) || (state->synctype == 36) )
 
     {
       //  1 -P25p1
       //  3 -X2-TDMA (inverted signal voice frame)
       //  5 -X2-TDMA (inverted signal data frame)
-      //  9 -NXDN (inverted voice frame)
       // 11 -DMR (inverted signal voice frame)
       // 13 -DMR (inverted signal data frame)
       // 17 -NXDN (inverted data frame)
       // 29 -NXDN (inverted FSW)
+      // 31 -YSF 
       // 36 -P25p2 
 
       int valid;
@@ -340,6 +340,7 @@ static int digitize (dsd_opts* opts, dsd_state* state, int symbol)
       // 12 +DMR (non inverted signal voice frame)
       // 16 +NXDN (non inverted data frame)
       // 28 +NXND (FSW)
+      // 30 +YSF
       // 35 +p25p2
 
       int valid;

--- a/src/dsd_file.c
+++ b/src/dsd_file.c
@@ -127,6 +127,7 @@ void PrintIMBEData (dsd_opts * opts, dsd_state * state, char *imbe_d) //for P25P
   int i, j, k;
   unsigned char b;
   unsigned char err;
+  UNUSED(err);
 
   err = (unsigned char) state->errs2;
   k = 0;
@@ -162,6 +163,7 @@ void PrintAMBEData (dsd_opts * opts, dsd_state * state, char *ambe_d)
   int i, j, k;
   unsigned char b;
   unsigned char err;
+  UNUSED(err);
 
   err = (unsigned char) state->errs2;
   k = 0;

--- a/src/dsd_frame.c
+++ b/src/dsd_frame.c
@@ -31,7 +31,7 @@ printFrameInfo (dsd_opts * opts, dsd_state * state)
   level = (int) state->max / 164;
   if (opts->verbose > 0)
     {
-      //fprintf (stderr,"inlvl: %2i%% ", level);
+      fprintf (stderr,"inlvl: %2i%% ", level);
     }
   if (state->nac != 0)
     {
@@ -59,8 +59,10 @@ processFrame (dsd_opts * opts, dsd_state * state)
   char duid[3];
   char nac[13];
   int level;
+  UNUSED2(nac, level);
 
   char status_0;
+  UNUSED(status_0);
   char bch_code[63];
   int index_bch_code;
   unsigned char parity;

--- a/src/dsd_frame.c
+++ b/src/dsd_frame.c
@@ -290,13 +290,7 @@ processFrame (dsd_opts * opts, dsd_state * state)
     //ysf
     else if ((state->synctype == 30) || (state->synctype == 31))
     {
-      //Do stuff
-      //fprintf(stderr, "YSF Sync! \n");
-      if ((opts->mbe_out_dir[0] != 0) && (opts->mbe_out_f == NULL))
-      {
-        //openMbeOutFile (opts, state);
-      }
-      //sprintf(state->fsubtype, " VOICE        ");
+      //relocate MBEout to inside frame handling -- Not Working Currently for YSF
       processYSF(opts, state);
       return;
     }

--- a/src/dsd_frame_sync.c
+++ b/src/dsd_frame_sync.c
@@ -228,13 +228,17 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
   {
     t_max = 10;
   }
-  //else if dPMR
+  //dPMR
   else if (opts->frame_dpmr == 1)
   {
     t_max = 12; //based on Frame_Sync_2 pattern
   }
-  //if Phase 2 (or YSF in future), then only 19
-  else if (state->lastsynctype == 35 || state->lastsynctype == 36) //P2
+  else if (opts->frame_ysf == 1)
+  {
+    t_max = 20; //20 on YSF
+  }
+  //if Phase 2, then only 19
+  else if (state->lastsynctype == 35 || state->lastsynctype == 36 )
   {
     t_max = 19; //Phase 2 S-ISCH is only 19
   }
@@ -573,24 +577,20 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
                 }
             }
           //YSF sync
-          strncpy(synctest20, (synctest_p - 19), 20); //double check make sure this is right
+          strncpy(synctest20, (synctest_p - 19), 20);
           if(opts->frame_ysf == 1) //(opts->frame_ysf == 1
           {
             if (0 == 0) //opts->inverted_ysf == 0
             {
               if (strcmp(synctest20, FUSION_SYNC) == 0)
               {
+                printFrameSync (opts, state, "+YSF ", synctest_pos + 1, modulation);
                 state->carrier = 1;
                 state->offset = synctest_pos;
                 state->max = ((state->max) + lmax) / 2;
                 state->min = ((state->min) + lmin) / 2;
-                fprintf (stderr, "\nYSF FUSION SYNC \n");
-                opts->inverted_ysf = 0; //should we set this here?
+                opts->inverted_ysf = 0;
                 state->lastsynctype = 30;
-                if ( opts->monitor_input_audio == 1)
-                {
-                  pa_simple_flush(opts->pulse_raw_dev_out, NULL);
-                }
                 return (30);
               }
             }
@@ -601,17 +601,13 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
             {
               if (strcmp(synctest20, INV_FUSION_SYNC) == 0)
               {
+                printFrameSync (opts, state, "-YSF ", synctest_pos + 1, modulation);
                 state->carrier = 1;
                 state->offset = synctest_pos;
                 state->max = ((state->max) + lmax) / 2;
                 state->min = ((state->min) + lmin) / 2;
-                fprintf (stderr, "\nINVERTED YSF FUSION SYNC \n");
-                opts->inverted_ysf = 1; //should we set this here?
+                opts->inverted_ysf = 1;
                 state->lastsynctype = 31;
-                if ( opts->monitor_input_audio == 1)
-                {
-                  pa_simple_flush(opts->pulse_raw_dev_out, NULL);
-                }
                 return (31);
               }
             }

--- a/src/dsd_frame_sync.c
+++ b/src/dsd_frame_sync.c
@@ -205,7 +205,7 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
     state->last_cc_sync_time = time(NULL); //set again to give another x seconds
   }
 
-  int i, j, t, o, dibit, sync, symbol, synctest_pos, lastt;
+  int i, t, dibit, sync, symbol, synctest_pos, lastt;
   char synctest[25];
   char synctest12[13]; //dPMR
   char synctest10[11]; //NXDN FSW only
@@ -217,10 +217,9 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
   char synctest48[49]; //EDACS
   char modulation[8];
   char *synctest_p;
-  int symboltest_pos; //symbol test position, match to synctest_pos
-  int symboltest_p[10240]; //make this an array instead
   char synctest_buf[10240]; //what actually is assigned to this, can't find its use anywhere?
   int lmin, lmax, lidx;
+  UNUSED2(synctest18, synctest21);
   
   //assign t_max value based on decoding type expected (all non-auto decodes first)
   int t_max; //maximum values allowed for t will depend on decoding type - NXDN will be 10, others will be more
@@ -246,7 +245,6 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
 
   int lbuf[t_max], lbuf2[t_max];
   int lsum;
-  char spectrum[64];
   //init the lbuf
   memset (lbuf, 0, sizeof(lbuf));
   memset (lbuf2, 0, sizeof(lbuf2));

--- a/src/dsd_import.c
+++ b/src/dsd_import.c
@@ -18,6 +18,7 @@ int csvGroupImport(dsd_opts * opts, dsd_state * state)
   int row_count = 0;
   int field_count = 0;
   long int group_number = 0; //local group number for array index value
+  UNUSED(group_number);
   int i = 0;
   while (fgets(buffer, BSIZE, fp)) {
     field_count = 0;

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -26,6 +26,8 @@
 #include "provoice_const.h"
 #include "git_ver.h"
 
+volatile uint8_t exitflag; //fix for issue #136
+
 int pretty_colors()
 {
     fprintf (stderr,"%sred\n", KRED);

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -447,6 +447,20 @@ noCarrier (dsd_opts * opts, dsd_state * state)
   sprintf (state->dpmr_caller_id, "%s", "      ");
   sprintf (state->dpmr_target_id, "%s", "      ");
 
+  //YSF Fusion Call Strings
+  sprintf (state->ysf_tgt, "%s", "          "); //10 spaces
+  sprintf (state->ysf_src, "%s", "          "); //10 spaces
+  sprintf (state->ysf_upl, "%s", "          "); //10 spaces
+  sprintf (state->ysf_dnl, "%s", "          "); //10 spaces
+  sprintf (state->ysf_rm1, "%s", "     "); //5 spaces
+  sprintf (state->ysf_rm2, "%s", "     "); //5 spaces
+  sprintf (state->ysf_rm3, "%s", "     "); //5 spaces
+  sprintf (state->ysf_rm4, "%s", "     "); //5 spaces
+  memset (state->ysf_txt, 0, sizeof(state->ysf_txt));
+  state->ysf_dt = 9;
+  state->ysf_fi = 9;
+  state->ysf_cm = 9;
+
 } //nocarrier
 
 void
@@ -1012,6 +1026,21 @@ initState (dsd_state * state)
   sprintf (state->dpmr_caller_id, "%s", "      ");
   sprintf (state->dpmr_target_id, "%s", "      ");
 
+  //YSF Fusion Call Strings
+  sprintf (state->ysf_tgt, "%s", "          "); //10 spaces
+  sprintf (state->ysf_src, "%s", "          "); //10 spaces
+  sprintf (state->ysf_upl, "%s", "          "); //10 spaces
+  sprintf (state->ysf_dnl, "%s", "          "); //10 spaces
+  sprintf (state->ysf_rm1, "%s", "     "); //5 spaces
+  sprintf (state->ysf_rm2, "%s", "     "); //5 spaces
+  sprintf (state->ysf_rm3, "%s", "     "); //5 spaces
+  sprintf (state->ysf_rm4, "%s", "     "); //5 spaces
+  memset (state->ysf_txt, 0, sizeof(state->ysf_txt));
+  state->ysf_dt = 9;
+  state->ysf_fi = 9;
+  state->ysf_cm = 9;
+
+
 } //init_state
 
 void
@@ -1100,6 +1129,7 @@ usage ()
   printf ("  -fn             Decode only NXDN96* (12.5 kHz)\n");
   printf ("  -fp             Decode only EDACS/ProVoice*\n");
   printf ("  -fm             Decode only dPMR*\n");
+  printf ("  -fy             Decode only YSF*\n");
   printf ("  -l            Disable DMR, dPMR, and NXDN input filtering\n");
   printf ("  -u <num>      Unvoiced speech quality (default=3)\n");
   printf ("  -xx           Expect non-inverted X2-TDMA signal\n");
@@ -1890,8 +1920,6 @@ main (int argc, char **argv)
               opts.frame_dpmr = 0;
               opts.frame_provoice = 0;
               opts.frame_ysf = 1;
-              state.samplesPerSymbol = 20; //10
-              state.symbolCenter = 10;
               opts.mod_c4fm = 1;
               opts.mod_qpsk = 0;
               opts.mod_gfsk = 0;
@@ -1902,8 +1930,7 @@ main (int argc, char **argv)
               state.dmr_stereo = 0;
               opts.dmr_mono = 0;
               sprintf (opts.output_name, "YSF");
-              fprintf (stderr,"Setting symbol rate to 2400 / second\n");
-              fprintf (stderr,"Decoding only YSF frames.\nNot working yet!\n");
+              fprintf (stderr,"Decoding only YSF frames. \n");
               }
               else if (optarg[0] == '2')
                 {

--- a/src/dsd_mbe.c
+++ b/src/dsd_mbe.c
@@ -139,7 +139,7 @@ void playMbeFiles (dsd_opts * opts, dsd_state * state, int argc, char **argv)
       else if (state->mbe_file_type > 0) //ambe files
       {
         readAmbe2450Data (opts, state, ambe_d);
-        int j, x;
+        int x;
         unsigned long long int k;
         if (state->K != 0) //apply Pr key
         {
@@ -185,7 +185,6 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
   int i;
   char imbe_d[88];
   char ambe_d[49];
-  char ambe_d_str[50];
   unsigned long long int k;
   int x;
 

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -208,7 +208,6 @@ void beeper (dsd_opts * opts, dsd_state * state, int type)
     beep = fopen (wav_name, "ro");
     uint8_t buf[1024];
     memset (buf, 0, sizeof(buf));
-    short blip = 0;
     int loop = 1;
     while (loop == 1)
     {
@@ -494,13 +493,10 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
   WINDOW *entry_win;
   WINDOW *info_win;
 	int highlight  = 1;
-  int highlightb = 1;
   int highlightc = 1;
 	int choice  = 0;
-  int choiceb = 0;
   int choicec = 0;
 	int c;
-  int d;
   int e;
 
   startx = 2;

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -85,7 +85,7 @@ char * SyncTypes[44] = {
   "NXDN",
   "NXDN",
   "YSF", //30
-  "YSF",
+  "YSF", //31
   "DMR",
   "DMR",
   "DMR",
@@ -338,7 +338,8 @@ char *choices[] = {
       "Decode dPMR",
       "Decode NXDN48",
       "Decode NXDN96",
-      "Decode DMR Stereo", //was X2-TDMA*
+      "Decode DMR TDMA",
+      "Decode YSF FUSION",
       "Toggle Signal Inversion",
       "Key Entry",
       "Reset Call History",
@@ -557,7 +558,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     }
 
     //Input Output Options
-    if (choice == 17)
+    if (choice == 18)
     {
       //test making a new window while other window is open
       test_win = newwin(HEIGHT-1, WIDTH+9, starty+5, startx+5);
@@ -1075,7 +1076,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     }
 
     //Privacy Key Entry
-    if (choice == 13)
+    if (choice == 14)
     {
       state->payload_keyid = 0;
       state->payload_keyidR = 0;
@@ -1529,6 +1530,32 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     }
     if (choice == 12)
     {
+      //Decode YSF Fusion
+      // resetState (state); //use sparingly, may cause memory leak
+      state->samplesPerSymbol = 10;
+      state->symbolCenter = 4;
+      sprintf (opts->output_name, "YSF");
+      opts->dmr_mono = 0;
+      opts->dmr_stereo  = 0; //this value is the end user option
+      state->dmr_stereo = 0; //this values toggles on and off depending on voice or data handling
+      opts->pulse_digi_rate_out = 48000;
+      opts->pulse_digi_out_channels = 1;
+      opts->frame_dstar = 0;
+      opts->frame_x2tdma = 0;
+      opts->frame_p25p1 = 0;
+      opts->frame_nxdn48 = 0;
+      opts->frame_nxdn96 = 0;
+      opts->frame_dmr = 0;
+      opts->frame_dpmr = 0;
+      opts->frame_provoice = 0;
+      opts->frame_ysf = 1;
+      opts->mod_c4fm = 1;
+      opts->mod_qpsk = 0;
+      opts->mod_gfsk = 0;
+      state->rf_mod = 0;
+    }
+    if (choice == 13)
+    {
       //Set all signal for inversion or uninversion
       if (opts->inverted_dmr == 0)
       {
@@ -1546,7 +1573,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       }
 
     }
-    if (choice == 14) //reset call history (usually if janky output when switching modes)
+    if (choice == 15) //reset call history (usually if janky output when switching modes)
     {
       for (short int k = 0; k <= 9; k++)
       {
@@ -1571,7 +1598,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
       state->lasttgR = 0;
     }
 
-    if (choice == 15) //toggle payload printing
+    if (choice == 16) //toggle payload printing
     {
       if (opts->payload == 0)
       {
@@ -1584,7 +1611,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
         fprintf(stderr, "Payload Off\n");
       }
     }
-    if (choice == 16)
+    if (choice == 17)
     {
       //hardset P2 WACN, SYSID, and NAC
       entry_win = newwin(6, WIDTH+16, starty+10, startx+10);
@@ -1637,7 +1664,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
 
 
     }
-    if (choice == 18)
+    if (choice == 19)
     {
       short int lrrpchoice = 0;
       entry_win = newwin(10, WIDTH+16, starty+10, startx+10);
@@ -1703,7 +1730,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
         opts->lrrp_out_file[0] = 0;
       }
     }
-    if (choice == 19)
+    if (choice == 20)
     {
       ncursesClose();
       //cleanup_rtlsdr_stream();
@@ -2396,6 +2423,66 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
   			state->dstarradioheader[32], state->dstarradioheader[33], state->dstarradioheader[34], state->dstarradioheader[35],
   			state->dstarradioheader[36], state->dstarradioheader[37], state->dstarradioheader[38]);
     }
+  }
+
+  //YSF
+  if (lls == 30 || lls == 31)
+  {
+    // printw ("\n");
+    printw ("| ");
+    printw ("Yaesu Fusion - ");
+    //insert data type and frame information
+    if (state->ysf_dt == 0) printw("Voice/Data T1 ");
+    if (state->ysf_dt == 1) printw("Data Full Rate");
+    if (state->ysf_dt == 2) printw("Voice/Data T2 ");
+    if (state->ysf_dt == 3) printw("V/W  Full Rate");
+    printw (" ");
+    if (state->ysf_cm == 0) printw("Group/CQ ");
+    if (state->ysf_cm == 3) printw("Private  ");
+    if (state->ysf_cm == 1) printw("Reserved ");
+    if (state->ysf_cm == 2) printw("Reserved ");
+
+    if (state->ysf_fi == 0) printw("HC ");
+    if (state->ysf_fi == 1) printw("CC ");
+    if (state->ysf_fi == 2) printw("TC ");
+    if (state->ysf_fi == 3) printw("XX ");
+
+    printw ("\n");
+    printw ("| ");
+    printw ("TGT: %s ", state->ysf_tgt);
+    printw ("SRC: %s ", state->ysf_src);
+    printw ("\n");
+    printw ("| ");
+    printw ("UPL: %s ", state->ysf_upl);
+    printw ("DNL: %s ", state->ysf_dnl);
+    printw ("\n");
+    printw ("| ");
+    printw ("RM1: %s ", state->ysf_rm1);
+    printw ("RM2: %s ", state->ysf_rm2);
+    printw ("\n");
+    printw ("| ");
+    printw ("RM3: %s ", state->ysf_rm3);
+    printw ("RM4: %s ", state->ysf_rm4);
+
+    //these texts can get pretty long and out of sorts, and lots of 0x20 spaces
+    //just going to leave these to only be in the console output
+
+    // printw ("\n");
+    // printw ("| ");
+    // printw ("TXT: ");
+    // for (i = 4; i < 8; i++)
+    // {
+    //   for (int j = 0; j < 20; j++)
+    //   {
+    //     //no spaces and no asterisks
+    //     if (state->ysf_txt[i][j] != 0x2A)
+    //       printw ("%c", state->ysf_txt[i][j]);
+    //   }
+    //   // printw (" "); //just a single space between each 'block'
+    // } 
+
+    printw ("\n");
+
   }
 
   //NXDN

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -2267,7 +2267,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
   {
     printw ("| Appending Raw Sig Audio WAV to file %s\n", opts->wav_out_file_raw);
   }
-  if (opts->symbol_out_file[0] != 0)
+  if (opts->symbol_out_f) //don't display when not actively capturing
   {
     printw ("| SymbolC Bin: %s\n", opts->symbol_out_file);
   }

--- a/src/dsd_reset.c
+++ b/src/dsd_reset.c
@@ -6,7 +6,7 @@
 void resetState (dsd_state * state)
 {
 
-  int i, j;
+  int i;
 
   //Dibit Buffer -- Free Allocated Memory
   // free (state->dibit_buf);

--- a/src/dsd_rigctl.c
+++ b/src/dsd_rigctl.c
@@ -35,7 +35,7 @@ void error(char *msg) {
 //
 int Connect (char *hostname, int portno)
 {
-    int sockfd, n;
+    int sockfd;
     struct sockaddr_in serveraddr;
     struct hostent *server;
 
@@ -222,9 +222,8 @@ bool GetSignalLevelEx(int sockfd, double *dBFS, int n_samp)
 //shoe in UDP input connection here...still having issues that I don't know how to resolve
 int UDPBind (char *hostname, int portno)
 {
-    int sockfd, n;
-    struct sockaddr_in serveraddr, client_addr;
-    struct hostent *server;
+    int sockfd;
+    struct sockaddr_in serveraddr;
 
     /* socket: create the socket */
     //UDP socket

--- a/src/dsd_serial.c
+++ b/src/dsd_serial.c
@@ -73,6 +73,7 @@ resumeScan (dsd_opts * opts, dsd_state * state)
 
   char cmd[16];
   ssize_t result;
+  UNUSED(result);
 
   if (opts->serial_fd > 0)
     {

--- a/src/dsd_symbol.c
+++ b/src/dsd_symbol.c
@@ -277,7 +277,8 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
 
       if (opts->use_cosine_filter)
         {
-          if ( (state->lastsynctype >= 10 && state->lastsynctype <= 13) || state->lastsynctype == 32 || state->lastsynctype == 33 || state->lastsynctype == 34)
+          if ( (state->lastsynctype >= 10 && state->lastsynctype <= 13) || state->lastsynctype == 32 || state->lastsynctype == 33 
+                || state->lastsynctype == 34 || state->lastsynctype == 30 || state->lastsynctype == 31)
           {
             sample = dmr_filter(sample);
           }

--- a/src/dsd_symbol.c
+++ b/src/dsd_symbol.c
@@ -20,7 +20,7 @@
 int
 getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
 {
-  short sample, sample2;
+  short sample;
   int i, sum, symbol, count;
   ssize_t result;
 
@@ -512,9 +512,9 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
     state->symbolc = fgetc(opts->symbolfile);
 
     //experimental throttle
-    useconds_t stime = state->symbol_throttle;
     if (state->use_throttle == 1)
     {
+      // useconds_t stime = state->symbol_throttle;
       // usleep(stime);
       usleep(.003); //very environment specific, tuning to cygwin
     }

--- a/src/dstar.c
+++ b/src/dstar.c
@@ -29,10 +29,8 @@
 
 void processDSTAR(dsd_opts * opts, dsd_state * state) {
 	// extracts AMBE frames from D-STAR voice frame
-	int i, j, dibit;
+	int i, dibit;
 	char ambe_fr[4][24];
-	unsigned char data[9];
-	unsigned int bits[4];
 	int framecount;
 	int sync_missed = 0;
 	unsigned char slowdata[4];
@@ -165,7 +163,7 @@ void processDSTAR(dsd_opts * opts, dsd_state * state) {
 
 void processDSTAR_HD(dsd_opts * opts, dsd_state * state) {
 
-	int i, j;
+	int j;
 	int radioheaderbuffer[660];
 
 	for (j = 0; j < 660; j++) {

--- a/src/dstar_header.c
+++ b/src/dstar_header.c
@@ -26,9 +26,8 @@ void dstar_header_decode(dsd_state * state, int radioheaderbuffer[660]) {
 	unsigned char radioheader[41];
 	int octetcount, bitcount, loop;
 	unsigned char bit2octet[] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
-	unsigned int FCSinheader;
-	unsigned int FCScalculated;
 	int len;
+	UNUSED(len);
 
 	scramble(radioheaderbuffer, radioheaderbuffer2);
 	deinterleave(radioheaderbuffer2, radioheaderbuffer);

--- a/src/edacs-bch3.c
+++ b/src/edacs-bch3.c
@@ -332,7 +332,8 @@ decode_bch()
 {
 	register int    i, j, u, q, t2, count = 0, syn_error = 0;
 	int             elp[1026][1024], d[1026], l[1026], u_lu[1026], s[1025];
-	int             root[200], loc[200], err[1024], reg[201];
+	int             root[200], loc[200], reg[201];
+	(void)(root);
 
 	t2 = 2 * t;
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -64,7 +64,6 @@ void edacs(dsd_opts * opts, dsd_state * state)
   unsigned char command = 0xFF;
   unsigned char mt1 = 0x1F;
   unsigned char mt2 = 0xF;
-  unsigned char mta = 0;
   unsigned char lcn = 0;
 
   //commands; may not use these anymore
@@ -72,10 +71,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
   unsigned int idcmd = 0xFD;
   unsigned int peercmd = 0xF88; //using for EA detection test
   unsigned int netcmd = 0xF3; //using for Networked Test
+  UNUSED2(vcmd, idcmd);
 
   state->edacs_vc_lcn = -1; //init on negative for ncurses and tuning
 
-  int i, j;
+  int i;
   int edacs_bit[241] = {0}; //zero out bit array and collect bits into it.
 
   for (i = 0; i < 240; i++) //288 bits every transmission minus 48 bit (24 dibit) sync pattern
@@ -381,6 +381,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int a = afs >> 7; 
         int fs = afs & 0x7F;
         int status  = (fr_1t & 0xF00000000) >> 32;
+        UNUSED(status);
         if (afs > 0) state->lastsrc = afs; 
         fprintf (stderr, "%s", KGRN);
         fprintf (stderr, " AFS [0x%03X] [%02d-%03d] LCN [%02d]", afs, a, fs, lcn);

--- a/src/nxdn_convolution.c
+++ b/src/nxdn_convolution.c
@@ -45,7 +45,7 @@ static const uint8_t CNXDNConvolution_BRANCH_TABLE1[] = {0U, 0U, 0U, 0U, 2U, 2U,
 static const uint8_t CNXDNConvolution_BRANCH_TABLE2[] = {0U, 2U, 2U, 0U, 0U, 2U, 2U, 0U};
 
 static const unsigned int CNXDNConvolution_NUM_OF_STATES_D2 = 8U;
-static const unsigned int CNXDNConvolution_NUM_OF_STATES = 16U;
+//static const unsigned int CNXDNConvolution_NUM_OF_STATES = 16U;
 static const uint32_t     CNXDNConvolution_M = 4U;
 static const unsigned int CNXDNConvolution_K = 5U;
 

--- a/src/nxdn_deperm.c
+++ b/src/nxdn_deperm.c
@@ -33,11 +33,11 @@ static const uint8_t scramble_t[] = { //values are the position values we need t
 	168, 170, 171, 174, 175, 176, 177, 181
 };
 
-static const int PARITY[] = {
-  0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 
-  1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 
-  1, 0, 0, 1, 1, 0, 1, 0, 0, 1
-};
+// static const int PARITY[] = {
+//   0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 
+//   1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 
+//   1, 0, 0, 1, 1, 0, 1, 0, 0, 1
+// };
 
 //decoding functions here
 void nxdn_descramble(uint8_t dibits[], int len)
@@ -976,7 +976,7 @@ void LFSRN(char * BufferIn, char * BufferOut, dsd_state * state)
   state->payload_miN = lfsr & 0x7FFF;
 }
 
-static inline int load_i(const uint8_t val[], int len) {
+int load_i(const uint8_t val[], int len) {
 	int acc = 0;
 	for (int i=0; i<len; i++){
 		acc = (acc << 1) + (val[i] & 1);
@@ -984,7 +984,7 @@ static inline int load_i(const uint8_t val[], int len) {
 	return acc;
 }
 
-static uint8_t crc6(const uint8_t buf[], int len)
+uint8_t crc6(const uint8_t buf[], int len)
 {
 	uint8_t s[6];
 	uint8_t a;
@@ -1002,7 +1002,7 @@ static uint8_t crc6(const uint8_t buf[], int len)
 	return load_i(s, 6);
 }
 
-static uint16_t crc12f(const uint8_t buf[], int len)
+uint16_t crc12f(const uint8_t buf[], int len)
 {
 	uint8_t s[12];
 	uint8_t a;
@@ -1026,7 +1026,7 @@ static uint16_t crc12f(const uint8_t buf[], int len)
 	return load_i(s, 12);
 }
 
-static uint16_t crc15(const uint8_t buf[], int len)
+uint16_t crc15(const uint8_t buf[], int len)
 {
 	uint8_t s[15];
 	uint8_t a;
@@ -1053,7 +1053,7 @@ static uint16_t crc15(const uint8_t buf[], int len)
 	return load_i(s, 15);
 }
 
-static uint16_t crc16cac(const uint8_t buf[], int len)
+uint16_t crc16cac(const uint8_t buf[], int len)
 {
 	uint32_t crc = 0xc3ee; //not sure why this though
 	uint32_t poly = (1<<12) + (1<<5) + 1; //poly is fine
@@ -1066,7 +1066,7 @@ static uint16_t crc16cac(const uint8_t buf[], int len)
 	return crc & 0xffff;
 }
 
-static uint8_t crc7_scch(uint8_t bits[], int len)
+uint8_t crc7_scch(uint8_t bits[], int len)
 {
 	uint8_t s[7];
 	uint8_t a;

--- a/src/nxdn_element.c
+++ b/src/nxdn_element.c
@@ -62,10 +62,7 @@ void NXDN_SACCH_Full_decode(dsd_opts * opts, dsd_state * state)
 void NXDN_Elements_Content_decode(dsd_opts * opts, dsd_state * state,
                                   uint8_t CrcCorrect, uint8_t * ElementsContent)
 {
-  uint32_t i;
   uint8_t MessageType;
-  uint64_t CurrentIV = 0;
-  unsigned long long int FullMessage = 0;
   /* Get the "Message Type" field */
   MessageType  = (ElementsContent[2] & 1) << 5;
   MessageType |= (ElementsContent[3] & 1) << 4;
@@ -332,6 +329,7 @@ void nxdn_ca_info_handler (dsd_state * state, uint32_t ca_info)
   uint32_t step = (ca_info >> 21) & 0x3; //Stepping
   uint32_t base = (ca_info >> 18) & 0x7; //Base Frequency
   uint32_t spare = ca_info & 0x3FF;
+  UNUSED(spare);
 
   //set state variable here to tell us to use DFA or Channel Versions
   if (RCN == 1)
@@ -355,7 +353,7 @@ void NXDN_decode_VCALL_ASSGN(dsd_opts * opts, dsd_state * state, uint8_t * Messa
   uint16_t DestinationID = 0;
   uint8_t  CallTimer = 0;
   uint16_t Channel = 0;
-  uint8_t  LocationIDOption = 0;
+  UNUSED(CallTimer);
 
   uint8_t  DuplexMode[32] = {0};
   uint8_t  TransmissionMode[32] = {0};
@@ -378,6 +376,7 @@ void NXDN_decode_VCALL_ASSGN(dsd_opts * opts, dsd_state * state, uint8_t * Messa
   uint8_t  bw = 0;
   uint16_t OFN = 0;
   uint16_t IFN = 0;
+  UNUSED2(bw, IFN);
 
   /* Decode "CC Option" */
   CCOption = (uint8_t)ConvertBitIntoBytes(&Message[8], 8);
@@ -701,6 +700,7 @@ void NXDN_decode_cch_info(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint16_t channel2 = 0;
   long int freq1 = 0;
   long int freq2 = 0;
+  UNUSED2(channel2sts, freq2);
   
   //DFA
   uint8_t  bw1 = 0;
@@ -709,6 +709,7 @@ void NXDN_decode_cch_info(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint8_t  bw2 = 0;
   uint16_t OFN2 = 0;
   uint16_t IFN2 = 0;
+  UNUSED(bw2);
 
   location_id = (uint32_t)ConvertBitIntoBytes(&Message[8], 24);
   channel1sts = (uint8_t)ConvertBitIntoBytes(&Message[32], 6);
@@ -850,6 +851,7 @@ void NXDN_decode_site_info(dsd_opts * opts, dsd_state * state, uint8_t * Message
   uint16_t channel2 = 0;
   long int freq1 = 0;
   long int freq2 = 0;
+  UNUSED2(freq1, freq2);
 
   location_id = (uint32_t)ConvertBitIntoBytes(&Message[8], 24);
   cs_info     = (uint16_t)ConvertBitIntoBytes(&Message[32], 16);
@@ -908,21 +910,17 @@ void NXDN_decode_adj_site(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint32_t adj1_site = 0; 
   uint32_t adj2_site = 0;
   uint32_t adj3_site = 0;
-  uint32_t adj4_site = 0;
   //options -- 6.5.38. Adjacent Site Option -- 4 LSB are Site Number, 2 MSB are spares
   uint8_t  adj1_opt = 0;
   uint8_t  adj2_opt = 0;
   uint8_t  adj3_opt = 0;
-  uint8_t  adj4_opt = 0;
-  //channel or OFN
+ //channel or OFN
   uint16_t adj1_chan = 0;
   uint16_t adj2_chan = 0;
   uint16_t adj3_chan = 0;
-  uint16_t adj4_chan = 0;
   //DFA only BW value
   uint8_t adj1_bw = 0;
   uint8_t adj2_bw = 0;
-  uint8_t adj3_bw = 0;
 
   fprintf (stderr, "%s", KYEL);
 
@@ -1044,7 +1042,6 @@ void NXDN_decode_VCALL(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint8_t  KeyID = 0;
   uint8_t  DuplexMode[32] = {0};
   uint8_t  TransmissionMode[32] = {0};
-  unsigned long long int FullMessage = 0;
 
   uint8_t MessageType;
   /* Get the "Message Type" field */
@@ -1085,6 +1082,7 @@ void NXDN_decode_VCALL(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint8_t idas = 0;
   uint8_t rep1 = 0;
   uint8_t rep2 = 0;
+  UNUSED(rep2);
   if (strcmp (state->nxdn_location_category, "Type-D") == 0) idas = 1;
   if (idas)
   {
@@ -1192,7 +1190,6 @@ void NXDN_decode_VCALL(dsd_opts * opts, dsd_state * state, uint8_t * Message)
 
 void NXDN_decode_VCALL_IV(dsd_opts * opts, dsd_state * state, uint8_t * Message)
 {
-  uint32_t i;
   state->payload_miN = 0; //zero out
   unsigned long long int IV = 0; 
 

--- a/src/nxdn_frame.c
+++ b/src/nxdn_frame.c
@@ -32,7 +32,6 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
   // length is implicitly 192, with frame sync in first 10 dibits
 	uint8_t dbuf[182]; 
 	uint8_t lich;
-	int answer_len = 0;
 	uint8_t answer[32];
 	uint8_t sacch_answer[32];
 	int lich_parity_received;
@@ -43,8 +42,6 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
 	int udch = 0;
 	int sacch = 0;
 	int cac = 0;
-	int sr_structure;
-	int sr_ran;
 
 	//new, and even more confusing NXDN Type-D / "IDAS" acronyms
 	int idas = 0;
@@ -57,6 +54,7 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
 	uint8_t lich_fc = 0; //Functional Channel Type
 	uint8_t lich_op = 0; //Options
 	uint8_t direction; //inbound or outbound direction
+	UNUSED2(lich_fc, lich_op);
 
 	uint8_t lich_dibits[8]; 
 	uint8_t sacch_bits[60];

--- a/src/nxdn_voice.c
+++ b/src/nxdn_voice.c
@@ -55,11 +55,10 @@ const int nZ[36] = { 5, 3, 4, 2, 3, 1,
 
 void nxdn_voice (dsd_opts * opts, dsd_state * state, int voice, uint8_t dbuf[182])
 {
-  int i, j, dibit;
+  int i;
   int start, stop;
   char ambe_fr[4][24];
 
-  unsigned char *pr;
   const int *w, *x, *y, *z;
 
   //these conditions will determine our starting and stopping value for voice

--- a/src/p25_lcw.c
+++ b/src/p25_lcw.c
@@ -17,6 +17,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
   uint8_t lc_svcopt = (uint8_t)ConvertBitIntoBytes(&LCW_bits[16], 8); //service options
   uint8_t lc_pf = LCW_bits[0]; //protect flag
   uint8_t lc_sf = LCW_bits[1]; //Implicit / Explicit MFID Format
+  UNUSED2(lc_opcode, lc_sf);
 
   if (lc_pf == 1) //check the protect flag -- if set, its an encrypted lcw
   {
@@ -60,6 +61,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
         uint16_t group = (uint16_t)ConvertBitIntoBytes(&LCW_bits[32], 16);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&LCW_bits[48], 24);
         fprintf (stderr, " - Group %d Source %d", group, source);
+        UNUSED2(res, explicit);
 
         //don't set this when zero, annoying blink occurs in ncurses
         if (group != 0) state->lasttg = group;
@@ -121,6 +123,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
         uint16_t channelt = (uint16_t)ConvertBitIntoBytes(&LCW_bits[40], 16);
         uint16_t channelr = (uint16_t)ConvertBitIntoBytes(&LCW_bits[56], 16);
         fprintf (stderr, "Ch: %04X TG: %d; ", channelt, group1);
+        UNUSED(channelr);
       }
 
       else if (lc_format == 0x45)
@@ -257,6 +260,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
         uint16_t channelr = (uint16_t)ConvertBitIntoBytes(&LCW_bits[48], 16);
         uint8_t cfva = (uint8_t)ConvertBitIntoBytes(&LCW_bits[64], 4);
         fprintf (stderr, " - RFSS %d Site %d CH %04X", rfssid, siteid, channelt);
+        UNUSED2(lra, channelr);
 
         //debug print only
         // fprintf (stderr, "\n  ");

--- a/src/p25p1_block.cpp
+++ b/src/p25p1_block.cpp
@@ -201,7 +201,6 @@ static uint16_t crc16_ok(const uint8_t bits[], unsigned int len) {
 int crc16_lb_bridge (int payload[190], int len)
 {
   int err = -2;
-  uint16_t crc = -2;
   uint8_t buf[190] = {0};
 
   for (int i = 0; i < len+16; i++) //add +16 here so we load the entire frame but only run crc on the len portion
@@ -264,7 +263,6 @@ static uint16_t crc12_ok(const uint8_t bits[], unsigned int len) {
 int crc12_xb_bridge (int payload[190], int len)
 {
   int err = -5;
-  uint16_t crc = -2;
   uint8_t buf[190] = {0};
 
   //need to load up the 12 crc bits as well, else it will fail on the check, but not on the crc calc

--- a/src/p25p1_hdu.c
+++ b/src/p25p1_hdu.c
@@ -26,6 +26,7 @@ read_dibit (dsd_opts* opts, dsd_state* state, char* output, int* status_count, i
 {
     int dibit;
     int status;
+    UNUSED(status);
 
     if (*status_count == 35) {
 
@@ -65,7 +66,6 @@ read_dibit_update_analog_data (dsd_opts* opts, dsd_state* state, char* output, u
         AnalogSignal* analog_signal_array, int* analog_signal_index)
 {
   unsigned int i;
-  unsigned int debug_left, debug_right;
 
   for (i=0; i<count; i+=2)
     {
@@ -215,9 +215,8 @@ correct_golay_dibits_6(char* corrected_hex_data, int hex_count, AnalogSignal* an
 void
 processHDU(dsd_opts* opts, dsd_state* state)
 {
-  char mi[73], mfid[9], algid[9], kid[17], tgid[17], tmpstr[255];
+  char mi[73], mfid[9], algid[9], kid[17], tgid[17];
   int i, j;
-  long talkgroup;
   int algidhex, kidhex;
   char hex[6];
   int status_count;
@@ -225,6 +224,7 @@ processHDU(dsd_opts* opts, dsd_state* state)
   unsigned long long int mihex1, mihex2, mihex3;
   char hex_data[20][6];    // Data in hex-words (6 bit words). A total of 20 hex words.
   char hex_parity[16][6];  // Parity of the data, again in hex-word format. A total of 16 parity hex words.
+  UNUSED4(mfid, tgid, status, mihex3);
 
   int irrecoverable_errors;
 

--- a/src/p25p1_heuristics.c
+++ b/src/p25p1_heuristics.c
@@ -315,7 +315,6 @@ int estimate_symbol(int rf_mod, P25Heuristics* heuristics, int previous_dibit, i
 static void debug_print_symbol_heuristics(int previous_dibit, int dibit, SymbolHeuristics* sh)
 {
     float mean, sd;
-    int k;
     int n;
 
     n = sh->count;

--- a/src/p25p1_ldu.c
+++ b/src/p25p1_ldu.c
@@ -67,6 +67,7 @@ process_IMBE (dsd_opts* opts, dsd_state* state, int* status_count)
   int j, dibit, status;
   char imbe_fr[8][23];
   const int *w, *x, *y, *z;
+  UNUSED(status);
 
   w = iW;
   x = iX;

--- a/src/p25p1_ldu1.c
+++ b/src/p25p1_ldu1.c
@@ -196,6 +196,7 @@ processLDU1 (dsd_opts* opts, dsd_state* state)
       int status;
       status = getDibit (opts, state) + '0';
       // TODO: do something useful with the status bits...
+      UNUSED(status);
   }
 
   // Error correct the hex_data using Reed-Solomon hex_parity

--- a/src/p25p1_ldu2.c
+++ b/src/p25p1_ldu2.c
@@ -33,6 +33,7 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
   int algidhex, kidhex;
   unsigned long long int mihex1, mihex2, mihex3;
   int status_count;
+  UNUSED(mihex3);
 
   char hex_data[16][6];    // Data in hex-words (6 bit words). A total of 16 hex words.
   char hex_parity[8][6];   // Parity of the data, again in hex-word format. A total of 12 parity hex words.
@@ -203,6 +204,7 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
       int status;
       status = getDibit (opts, state) + '0';
       // TODO: do something useful with the status bits...
+      UNUSED(status);
   }
 
   // Error correct the hex_data using Reed-Solomon hex_parity

--- a/src/p25p1_mdpu.c
+++ b/src/p25p1_mdpu.c
@@ -64,14 +64,13 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
   int flushing_bits[196]; //for flushing the trellis state machine
   memset (flushing_bits, 0, sizeof(flushing_bits));
 
-  int i, j, k, b, x, y;
+  int i, j, k, x;
   int ec[3]; //error value returned from (block_deinterleave)
   int err[2]; //error value returned from ccrc16 or crc32
   memset (ec, -2, sizeof(ec));
   memset (err, -2, sizeof(err));
 
   int skipdibit = 14; //initial status dibit will occur at 14, then add 36 each time it occurs
-  int protectbit = 0;
   int MFID = 0xFF; //Manufacturer ID
 
   uint8_t mpdu_byte[36];
@@ -214,12 +213,14 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
       int channelt = (mpdu_byte[15] << 8) | mpdu_byte[16];
       int channelr = (mpdu_byte[17] << 8) | mpdu_byte[18];
       int ssc =  mpdu_byte[19];
+      UNUSED3(res_a, res_b, ssc);
       fprintf (stderr, "%s",KYEL);
       fprintf (stderr, "\n Network Status Broadcast MBT - Extended \n");
       fprintf (stderr, "  LRA [%02X] WACN [%05lX] SYSID [%03X] NAC [%03llX]\n", lra, wacn, sysid, state->p2_cc);
       fprintf (stderr, "  CHAN-T [%04X] CHAN-R [%04X]", channelt, channelr);
       long int ct_freq = process_channel_to_freq(opts, state, channelt);
       long int cr_freq = process_channel_to_freq(opts, state, channelr);
+      UNUSED(cr_freq);
       
       state->p25_cc_freq = ct_freq;
       state->p25_cc_is_tdma = 0; //flag off for CC tuning purposes when system is qpsk
@@ -293,6 +294,7 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
 			int group = (mpdu_byte[18] << 8) | mpdu_byte[19];
 			long int freq1 = 0;
 			long int freq2 = 0;
+      UNUSED2(source, freq2);
       fprintf (stderr, "%s\n ",KYEL);
       if (svc & 0x80) fprintf (stderr, " Emergency");
       if (svc & 0x40) fprintf (stderr, " Encrypted");
@@ -391,6 +393,7 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
 			long int target = (mpdu_byte[19] << 16) |(mpdu_byte[20] << 8) | mpdu_byte[21];
 			long int freq1 = 0;
 			long int freq2 = 0;
+      UNUSED(freq2);
       fprintf (stderr, "%s\n ",KYEL);
       if (svc & 0x80) fprintf (stderr, " Emergency");
       if (svc & 0x40) fprintf (stderr, " Encrypted");

--- a/src/p25p1_tdu.c
+++ b/src/p25p1_tdu.c
@@ -32,6 +32,7 @@ processTDU (dsd_opts* opts, dsd_state* state)
         int status;
         status = getDibit (opts, state) + '0';
         // TODO: do something useful with the status bits...
+        UNUSED(status);
     }
     
     //reset some strings -- since its a tdu, blank out any call strings, only want during actual call

--- a/src/p25p1_tdulc.c
+++ b/src/p25p1_tdulc.c
@@ -305,6 +305,7 @@ processTDULC (dsd_opts* opts, dsd_state* state)
       int status;
       status = getDibit (opts, state) + '0';
       // TODO: do something useful with the status bits...
+      UNUSED(status);
   }
 
   // Put the corrected data into the DSD structures

--- a/src/p25p1_tsbk.c
+++ b/src/p25p1_tsbk.c
@@ -41,7 +41,7 @@ void processTSBK(dsd_opts * opts, dsd_state * state)
   int flushing_bits[196]; //for flushing the trellis state machine
   memset (flushing_bits, 0, sizeof(flushing_bits));
   
-  int i, j, k, b, x, y;
+  int i, j, k, x;
   int ec = -2; //error value returned from (block_deinterleave)
   int err = -2; //error value returned from crc16_lb_bridge
   int skipdibit = 14; //initial status dibit will occur at 14, then add 36 each time it occurs

--- a/src/p25p2_frame.c
+++ b/src/p25p2_frame.c
@@ -375,6 +375,7 @@ void process_ISCH (dsd_opts * opts, dsd_state * state)
 			int free = (isch_decoded >> 2) & 0x1;
 			int isch_loc = (isch_decoded >> 3) & 0x3;
 			int chan_num = (isch_decoded >> 5) & 0x3;
+			UNUSED2(uf_count, free);
 			state->p2_vch_chan_num = chan_num;
 
 			//old rules for entire superframe worth
@@ -674,7 +675,6 @@ void process_P2_DUID (dsd_opts * opts, dsd_state * state)
 	int err_counter = 0;
 
 	//add time to mirror printFrameSync
-  	time_t now;
   	char * getTime(void) //get pretty hh:mm:ss timestamp
   	{
     	time_t t = time(NULL);

--- a/src/p25p2_vpdu.c
+++ b/src/p25p2_vpdu.c
@@ -89,6 +89,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 		if (MAC[1+len_a] == 0xA3 && MAC[2+len_a] == 0x90)
 		{
 			int mfid = MAC[2+len_a];
+			UNUSED(mfid);
 			int channel  = (MAC[5+len_a] << 8) | MAC[6+len_a];
 			int sgroup = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			long int freq = 0;
@@ -168,6 +169,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int channelr = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			int sgroup = (MAC[9+len_a] << 8) | MAC[10+len_a];
 			long int freq = 0;
+			UNUSED2(mfid, channelr);
 			fprintf (stderr, "\n MFID90 Group Regroup Channel Grant - Explicit");
 			fprintf (stderr, "\n  CHAN [%04X] Group [%d][%04X]", channel, sgroup, sgroup);
 			freq = process_channel_to_freq (opts, state, channel);
@@ -546,7 +548,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			long int freq1t = 0;
 			long int freq1r = 0;
 			long int freq2t = 0;
-			long int freq2r = 0;
+			UNUSED(freq1r);
 
 			fprintf (stderr, "\n Group Voice Channel Grant Update Multiple - Explicit");
 			fprintf (stderr, "\n  SVC [%02X] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc1, channelt1, channelr1, group1, group1);
@@ -973,6 +975,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int group = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			long int freq1 = 0;
 			long int freq2 = 0;
+			UNUSED(freq2);
 
 			fprintf (stderr, "\n");
 
@@ -1079,7 +1082,6 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 		//Authentication Response - Abbreviated
 		if (MAC[1+len_a] == 0x78) 
 		{
-			int res1 = 0; //don't really care about this value, just setting it to zero
 			int source = (MAC[8+len_a] << 16) | (MAC[9+len_a] << 8) | MAC[10+len_a];
 			fprintf (stderr, "\n Authentication Response - Abbreviated \n");
 			fprintf (stderr, "  Source [%08d][%06X] ", source, source);
@@ -1378,6 +1380,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int len_grg = MAC[3+len_a] & 0x3F;
 			int grg = MAC[4+len_a] >> 5; //3 bits
 			int ssn = MAC[4+len_a] & 0x1F; //5 bits
+			UNUSED(ssn);
 			fprintf (stderr, "\n MFIDA4 Group Regroup Explicit Encryption Command\n");
 			//fprintf (stderr, " LEN [%02X] GRG [%02X]\n", len_grg, grg);
 			if (grg & 0x2) //if grg == wgid //&0x2 according to OP25
@@ -1389,6 +1392,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 				int t2 = (MAC[12+len_a] << 8) | MAC[13+len_a];
 				int t3 = (MAC[14+len_a] << 8) | MAC[15+len_a];
 				int t4 = (MAC[16+len_a] << 8) | MAC[17+len_a];
+				UNUSED4(t1, t2, t3, t4);
 				fprintf (stderr, "  SG [%05d] KEY [%04X] ALG [%02X]\n  ", sg, key, alg);
 				int a = 0;
 				int wgid = 0;
@@ -1512,6 +1516,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int channel = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			int sysclass = MAC[9+len_a];
 			int lcolorcode = ((MAC[10+len_a] & 0xF) << 8) | MAC[11+len_a];
+			UNUSED(sysclass);
 			fprintf (stderr, "\n Network Status Broadcast - Abbreviated \n");
 			fprintf (stderr, "  LRA [%02X] WACN [%05X] SYSID [%03X] NAC [%03X] CHAN-T [%04X]", lra, lwacn, lsysid, lcolorcode, channel);
 			state->p25_cc_freq = process_channel_to_freq (opts, state, channel);
@@ -1541,6 +1546,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int channelr = (MAC[9+len_a] << 8) | MAC[10+len_a];
 			int sysclass = MAC[9+len_a];
 			int lcolorcode = ((MAC[12+len_a] & 0xF) << 8) | MAC[13+len_a];
+			UNUSED(sysclass);
 			fprintf (stderr, "\n Network Status Broadcast - Extended \n");
 			fprintf (stderr, "  LRA [%02X] WACN [%05X] SYSID [%03X] NAC [%03X] CHAN-T [%04X] CHAN-R [%04X]", lra, lwacn, lsysid, lcolorcode, channelt, channelr);
 			state->p25_cc_freq = process_channel_to_freq (opts, state, channelt);

--- a/src/p25p2_xcch.c
+++ b/src/p25p2_xcch.c
@@ -41,16 +41,17 @@ void process_SACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[180]
 	int mco_a = 69;
 	//mco will tell us the number of octets to use in variable length MAC PDUs, need a table or something
 	mco_a = (payload[10] << 5) | (payload[11] << 4) | (payload[12] << 3) | (payload[13] << 2) | (payload[14] << 0) | (payload[15] << 0);
+	UNUSED3(mac_offset, b, mco_a);
 
 	//get the second mco after determining first message length, see what second mco is and plan accordingly
 	int mco_b = 69;
+	UNUSED(mco_b);
 
 	//attempt CRC12 check to validate or reject PDU
 	int err = -2;
 	if (state->p2_is_lcch == 0)
 	{
-		int len =
-		err = crc12_xb_bridge(payload, 180-12);
+		int err = crc12_xb_bridge(payload, 180-12);
 		if (err != 0) //CRC Failure, warn or skip.
 		{
 			if (SMAC[1] == 0x0) //NULL PDU Check, pass if NULL type
@@ -334,6 +335,7 @@ void process_FACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[156]
 	opcode = (payload[0] << 2) | (payload[1] << 1) | (payload[2] << 0);
 	int mac_offset = 0;
 	mac_offset = (payload[3] << 2) | (payload[4] << 1) | (payload[5] << 0);
+	UNUSED(mac_offset);
 
 	//attempt CRC check to validate or reject PDU
 	int err = -2;

--- a/src/provoice.c
+++ b/src/provoice.c
@@ -23,7 +23,6 @@ void processProVoice (dsd_opts * opts, dsd_state * state)
 
   uint8_t spacer_bit[8]; //check this value to see if its a status thing (like P25 P1)
   memset (spacer_bit, 0, sizeof (spacer_bit));
-  uint8_t spacer = 0;
   uint16_t bf = 0; //the 16-bit value in-between imbe 2 and imbe 3 that is usually 2175
 
   fprintf (stderr," VOICE");

--- a/src/rtl_sdr_fm.cpp
+++ b/src/rtl_sdr_fm.cpp
@@ -908,12 +908,10 @@ static unsigned int chars_to_int(unsigned char* buf) {
 }
 
 static void *socket_thread_fn(void *arg) {
-	struct demod_state *d = static_cast<demod_state*>(arg);
-  int r, n;
-  int sockfd, newsockfd, portno;
-  socklen_t clilen;
+  int n;
+  int sockfd;
   unsigned char buffer[5];
-  struct sockaddr_in serv_addr, cli_addr;
+  struct sockaddr_in serv_addr;
 
 	sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
@@ -935,7 +933,7 @@ static void *socket_thread_fn(void *arg) {
 
 	fprintf (stderr, "Main socket started! :-) Tuning enabled on UDP/%d \n", port);
 
-	int new_freq, demod_type, new_squelch, new_gain, agc_mode;
+	int new_freq;
 
 	while((n = read(sockfd,buffer,5)) != 0) {
 		if(buffer[0] == 0) {
@@ -962,7 +960,6 @@ void rtlsdr_sighandler()
 
 void open_rtlsdr_stream(dsd_opts *opts)
 {
-  struct sigaction sigact;
   int r;
 	rtl_bandwidth =  opts->rtl_bandwidth * 1000; //reverted back to straight value
 	bandwidth_multiplier = (bandwidth_divisor / rtl_bandwidth);

--- a/src/x2tdma_data.c
+++ b/src/x2tdma_data.c
@@ -29,6 +29,7 @@ processX2TDMAdata (dsd_opts * opts, dsd_state * state)
   char cc[4];
   int aiei;
   char bursttype[5];
+  UNUSED4(syncdata, cachdata, cc, aiei);
 
 #ifdef X2TDMA_DUMP
   int k;

--- a/src/x2tdma_voice.c
+++ b/src/x2tdma_voice.c
@@ -39,6 +39,7 @@ processX2TDMAvoice (dsd_opts * opts, dsd_state * state)
   int mutecurrentslot;
   int algidhex, kidhex;
   int msMode;
+  UNUSED5(lcformat, mfid, lcinfo, cachdata, parity);
 
 #ifdef X2TDMA_DUMP
   int k;

--- a/src/ysf.c
+++ b/src/ysf.c
@@ -1,85 +1,74 @@
 /*-------------------------------------------------------------------------------
  * ysf.c
- * Yaesu Fusion Decoder for DSD
+ * Yaesu Fusion Decoder (WIP)
+ *
+ * Bits of code from DSDcc, Osmocom OP25, and gr-ysf sprinkled in
+ *
  *
  * LWVMOBILE
- * 2022-04 DSD-FME Florida Man Edition
+ * 2023-07 DSD-FME Florida Man Edition
  *-----------------------------------------------------------------------------*/
- /*
-  * Copyright (C) 2010 DSD Author
-  * GPG Key ID: 0x3F1D7FD0 (74EF 430D F7F2 0A48 FCE6  F630 FAA2 635D 3F1D 7FD0)
-  *
-  * Permission to use, copy, modify, and/or distribute this software for any
-  * purpose with or without fee is hereby granted, provided that the above
-  * copyright notice and this permission notice appear in all copies.
-  *
-  * THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH
-  * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-  * AND FITNESS.  IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT,
-  * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-  * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
-  * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-  * PERFORMANCE OF THIS SOFTWARE.
-  */
-
-
 #include "dsd.h"
 
-const int fichInterleave[100] = {
-        0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
-        1, 6, 11, 16, 21, 26, 31, 36, 41, 46, 51, 56, 61, 66, 71, 76, 81, 86, 91, 96,
-        2, 7, 12, 17, 22, 27, 32, 37, 42, 47, 52, 57, 62, 67, 72, 77, 82, 87, 92, 97,
-        3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78, 83, 88, 93, 98,
-        4, 9, 14, 19, 24, 29, 34, 39, 44, 49, 54, 59, 64, 69, 74, 79, 84, 89, 94, 99,
+/* thx gr-ysf fr_vch_decoder_bb_impl.cc * Copyright 2015 Mathias Weyland */
+// I hold Sylvain Munaut in high esteem for figuring this out.
+uint8_t fr_interleave[144] = {
+0,   7,  12,  19,  24,  31,  36,  43,  48,  55,  60,  67,     // [  0 -  11] yellow message
+72,  79,  84,  91,  96, 103, 108, 115, 120, 127, 132,         // [ 12 -  22] yellow FEC
+139,   1,   6,  13,  18,  25,  30,  37,  42,  49,  54,  61,   // [ 23 -  34] orange message
+66,  73,  78,  85,  90,  97, 102, 109, 114, 121, 126,         // [ 35 -  45] orange FEC
+133, 138,   2,   9,  14,  21,  26,  33,  38,  45,  50,  57,   // [ 46 -  57] red message
+62,  69,  74,  81,  86,  93,  98, 105, 110, 117, 122,         // [ 58 -  68] red FEC
+129, 134, 141,   3,   8,  15,  20,  27,  32,  39,  44,  51,   // [ 69 -  80] pink message
+56,  63,  68,  75,  80,  87,  92,  99, 104, 111, 116,         // [ 81 -  91] pink FEC
+123, 128, 135, 140,   4,  11,  16,  23,  28,  35,  40,        // [ 92 - 102] dark blue message
+47,  52,  59,  64,                                            // [103 - 106] dark blue FEC
+71,  76,  83,  88,  95, 100, 107, 112, 119, 124, 131,         // [107 - 117] light blue message
+136, 143,   5,  10,                                           // [118 - 121] light blue FEC
+17,  22,  29,  34,  41,  46,  53,  58,  65,  70,  77,         // [122 - 132] green message
+82,  89,  94, 101,                                            // [133 - 136] green FEC
+106, 113, 118, 125, 130, 137, 142,                            // [137 - 143] unprotected
 };
 
-const int vd2Interleave[104] = {
-         0,  26,  52,  78,
-         1,  27,  53,  79,
-         2,  28,  54,  80,
-         3,  29,  55,  81,
-         4,  30,  56,  82,
-         5,  31,  57,  83,
-         6,  32,  58,  84,
-         7,  33,  59,  85,
-         8,  34,  60,  86,
-         9,  35,  61,  87,
-        10,  36,  62,  88,
-        11,  37,  63,  89,
-        12,  38,  64,  90,
-        13,  39,  65,  91,
-        14,  40,  66,  92,
-        15,  41,  67,  93,
-        16,  42,  68,  94,
-        17,  43,  69,  95,
-        18,  44,  70,  96,
-        19,  45,  71,  97,
-        20,  46,  72,  98,
-        21,  47,  73,  99,
-        22,  48,  74, 100,
-        23,  49,  75, 101,
-        24,  50,  76, 102,
-        25,  51,  77, 103
+uint8_t pn95[512] =
+{
+  1, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1,
+  0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 
+  1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 
+  0, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 
+  1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 
+  1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 
+  1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 
+  0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 
+  1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 
+  0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 
+  1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0, 
+  0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0, 0, 
+  0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 
+  0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 
+  1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 
+  0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 
+  0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 
+  1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 
+  0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 
+  0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 
+  0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 
+  0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 
+  1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 
+  1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 
+  0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 
+  0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 
+  1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 
+  1, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 
+  1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 
+  0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 
+  0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 
+  0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1
 };
 
-const int vfrInterleave[144] = { //IMBE 7200x4400 full rate interleave schedule
-         0,  24,  48,  72,  96, 120,  25,   1,  73,  49, 121,  97,
-         2,  26,  50,  74,  98, 122,  27,   3,  75,  51, 123,  99,
-         4,  28,  52,  76, 100, 124,  29,   5,  77,  53, 125, 101,
-         6,  30,  54,  78, 102, 126,  31,   7,  79,  55, 127, 103,
-         8,  32,  56,  80, 104, 128,  33,   9,  81,  57, 129, 105,
-        10,  34,  58,  82, 106, 130,  35,  11,  83,  59, 131, 107,
-        12,  36,  60,  84, 108, 132,  37,  13,  85,  61, 133, 109,
-        14,  38,  62,  86, 110, 134,  39,  15,  87,  63, 135, 111,
-        16,  40,  64,  88, 112, 136,  41,  17,  89,  65, 137, 113,
-        18,  42,  66,  90, 114, 138,  43,  19,  91,  67, 139, 115,
-        20,  44,  68,  92, 116, 140,  45,  21,  93,  69, 141, 117,
-        22,  46,  70,  94, 118, 142,  47,  23,  95,  71, 143, 119
-};
-
-//half-rate ambe3600x2450 interleave schedule
-const int YSFrW[36] = {
-  0, 1, 0, 1, 0, 1,
+//half-rate (from NXDN)
+const int YnW[36] = 
+{ 0, 1, 0, 1, 0, 1,
   0, 1, 0, 1, 0, 1,
   0, 1, 0, 1, 0, 1,
   0, 1, 0, 1, 0, 2,
@@ -87,9 +76,8 @@ const int YSFrW[36] = {
   0, 2, 0, 2, 0, 2
 };
 
-// bit index
-const int YSFrX[36] = {
-  23, 10, 22, 9, 21, 8,
+const int YnX[36] = 
+{ 23, 10, 22, 9, 21, 8,
   20, 7, 19, 6, 18, 5,
   17, 4, 16, 3, 15, 2,
   14, 1, 13, 0, 12, 10,
@@ -97,10 +85,8 @@ const int YSFrX[36] = {
   8, 6, 7, 5, 6, 4
 };
 
-// bit 0
-// frame index
-const int YSFrY[36] = {
-  0, 2, 0, 2, 0, 2,
+const int YnY[36] = 
+{ 0, 2, 0, 2, 0, 2,
   0, 2, 0, 3, 0, 3,
   1, 3, 1, 3, 1, 3,
   1, 3, 1, 3, 1, 3,
@@ -108,9 +94,8 @@ const int YSFrY[36] = {
   1, 3, 1, 3, 1, 3
 };
 
-// bit index
-const int YSFrZ[36] = {
-  5, 3, 4, 2, 3, 1,
+const int YnZ[36] = 
+{ 5, 3, 4, 2, 3, 1,
   2, 0, 1, 13, 0, 12,
   22, 11, 21, 10, 20, 9,
   19, 8, 18, 7, 17, 6,
@@ -118,170 +103,1094 @@ const int YSFrZ[36] = {
   13, 2, 12, 1, 11, 0
 };
 
-void processYSF(dsd_opts * opts, dsd_state * state) //YSF
+//M = 26, depth of 4; -- work on replacing this with a simple deinterleave function like FICH and DCH use
+const int vd2Interleave[104] = {
+0,  26,  52,  78,
+1,  27,  53,  79,
+2,  28,  54,  80,
+3,  29,  55,  81,
+4,  30,  56,  82,
+5,  31,  57,  83,
+6,  32,  58,  84,
+7,  33,  59,  85,
+8,  34,  60,  86,
+9,  35,  61,  87,
+10,  36,  62,  88,
+11,  37,  63,  89,
+12,  38,  64,  90,
+13,  39,  65,  91,
+14,  40,  66,  92,
+15,  41,  67,  93,
+16,  42,  68,  94,
+17,  43,  69,  95,
+18,  44,  70,  96,
+19,  45,  71,  97,
+20,  46,  72,  98,
+21,  47,  73,  99,
+22,  48,  74, 100,
+23,  49,  75, 101,
+24,  50,  76, 102,
+25,  51,  77, 103
+};
+
+void ysf_dch_decode (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, int err, uint8_t input[])
 {
-  //480 dibits - 20 dibit sync leaves 460 dibits (920 bits) each 'superframe'
-  fprintf (stderr, "processYSF Function \n");
-  uint32_t i, j, k;
-  unsigned char dibit;
+  //TODO: Per Call WAV files using these strings
+  int i, j, k;
+  char dch_bytes[20];
+  memset (dch_bytes, 0, sizeof(dch_bytes));
+  char string1[11];
+  char string2[11];
+  char string3[21];
+  char C;
+
+  for (i = 0; i < 20; i++)
+    dch_bytes[i] = (char)ConvertBitIntoBytes(&input[i*8], 8);
+
+  switch(bn){ //using bn here so we can use the frame number for sorting the text messages found in here
+    case 0: //CSD1
+
+      //Destination / Target
+      memcpy (string1, dch_bytes, 10);
+      string1[10] = '\0';
+      fprintf (stderr, "TGT: ");
+      fprintf (stderr, "%s ", string1);
+
+      //Source
+      memcpy (string2, dch_bytes+10, 10);
+      string2[10] = '\0';
+      fprintf (stderr, "SRC: ");
+      fprintf (stderr, "%s ", string2);
+
+      //Copy both to Ncurses Call String
+      memcpy (state->ysf_tgt, dch_bytes, 10);
+      state->ysf_tgt[10] = '\0';
+
+      memcpy (state->ysf_src, dch_bytes+10, 10);
+      state->ysf_src[10] = '\0';
+
+      break;
+    case 1: //CSD2
+
+      //Uplink
+      memcpy (string1, dch_bytes, 10);
+      string1[10] = '\0';
+      fprintf (stderr, "U/L: ");
+      fprintf (stderr, "%s ", string1);
+
+      //Downlink
+      memcpy (string2, dch_bytes+10, 10);
+      string2[10] = '\0';
+      fprintf (stderr, "D/L: ");
+      fprintf (stderr, "%s ", string2);
+      
+      //Copy both to Ncurses Call String
+      memcpy (state->ysf_upl, dch_bytes, 10);
+      state->ysf_upl[10] = '\0';
+
+      state->ysf_dnl[10] = '\0';
+      memcpy (state->ysf_dnl, dch_bytes+10, 10);
+
+      break;
+    case 2:
+      // fprintf (stderr, "TXT: ");
+      memcpy (string3, dch_bytes, 20);
+      string3[20] = '\0';
+      fprintf (stderr, "%s ", string3);
+
+      // if (fn == 0) memset (state->ysf_txt, 0, sizeof(state->ysf_txt));
+      //copy text to txt storage -- works now (had to expand storage space), but is cumbersome in ncurses, especially when garbage strings show up
+      // if (fn < 20)
+      // {
+      //   //switch to checking each byte for a 'nice' ASCII character and 
+      //   //not a 'naughty' del/rem/break/garbled non ASCII/ALPHANUMERIC type character  
+      //   for (i = 0; i < 20; i++)
+      //   {
+      //     C = dch_bytes[i]; //skipping 0x20 space key
+      //     if (C > 0x20 && C < 0x7F) state->ysf_txt[fn][i] = C;
+      //     else state->ysf_txt[fn][i] = 0; //NULL
+      //   }
+      // }
+        
+      break;
+      
+    default:
+      break;
+
+  }
+
+}
+
+void ysf_dch_decode2 (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, int err, uint8_t input[])
+{
+  //TODO: Per Call WAV files using these strings
+  int i, j, k;
+  char dch_bytes[20];
+  memset (dch_bytes, 0, sizeof(dch_bytes));
+  char string[11];
+  char rem1[6];
+  char rem2[6];
+
+  for (i = 0; i < 10; i++)
+    dch_bytes[i] = (char)ConvertBitIntoBytes(&input[i*8], 8);
+
+  switch(fn){
+    case 0:
+      //Destination / Target
+      fprintf (stderr, "TGT: ");
+      memcpy (string, dch_bytes, 10);
+      string[10] = '\0';
+      fprintf (stderr, "%s", string);
+
+      memcpy (state->ysf_tgt, dch_bytes, 10);
+      state->ysf_tgt[10] = '\0';
+
+      break;
+    case 1:
+      //Source
+      memcpy (string, dch_bytes, 10);
+      string[10] = '\0';
+      fprintf (stderr, "SRC: ");
+      fprintf (stderr, "%s", string);
+
+      memcpy (state->ysf_src, dch_bytes, 10);
+      state->ysf_src[10] = '\0';
+
+      break;
+    case 2:
+      //Uplink
+      memcpy (string, dch_bytes, 10);
+      string[10] = '\0';
+      fprintf (stderr, "U/L: ");
+      fprintf (stderr, "%s", string);
+
+      memcpy (state->ysf_upl, dch_bytes, 10);
+      state->ysf_upl[10] = '\0';
+
+      break;
+    case 3:
+      //Downlink
+      memcpy (string, dch_bytes, 10);
+      string[10] = '\0';
+      fprintf (stderr, "D/L: ");
+      fprintf (stderr, "%s", string);
+
+      state->ysf_dnl[10] = '\0';
+      memcpy (state->ysf_dnl, dch_bytes, 10);
+
+      break;
+    case 4:
+      //Remarks 1 and 2
+      memcpy (rem1, dch_bytes, 5);
+      rem1[5] = '\0';
+      fprintf (stderr, "RM1: ");
+      fprintf (stderr, "%s ", rem1);
+      
+      memcpy (rem2, dch_bytes+5, 5);
+      rem2[5] = '\0';
+      fprintf (stderr, "RM2: ");
+      fprintf (stderr, "%s ", rem2);
+
+      memcpy (state->ysf_rm1, dch_bytes, 5);
+      state->ysf_rm1[5] = '\0';
+
+      memcpy (state->ysf_rm2, dch_bytes+5, 5);
+      state->ysf_rm2[5] = '\0';
+
+      break;
+    case 5:
+      //Remarks 3 and 4
+      memcpy (rem1, dch_bytes, 5);
+      rem1[5] = '\0';
+      fprintf (stderr, "RM3: ");
+      fprintf (stderr, "%s ", rem1);
+      
+      memcpy (rem2, dch_bytes+5, 5);
+      rem2[5] = '\0';
+      fprintf (stderr, "RM4: ");
+      fprintf (stderr, "%s ", rem2);
+
+      memcpy (state->ysf_rm3, dch_bytes, 5);
+      state->ysf_rm3[5] = '\0';
+
+      memcpy (state->ysf_rm4, dch_bytes+5, 5);
+      state->ysf_rm4[5] = '\0';
+      break;
+
+    default:
+      break;
+  }
+
+}
+
+static inline uint16_t crc16ysf(const uint8_t buf[], int len)
+{
+  uint32_t poly = (1<<12) + (1<<5) + (1<<0);
+  uint32_t crc = 0;
+  for(int i=0; i<len; i++) 
+  {
+    uint8_t bit = buf[i] & 1;
+    crc = ((crc << 1) | bit) & 0x1ffff;
+    if (crc & 0x10000) crc = (crc & 0xffff) ^ poly;
+  }
+  crc = crc ^ 0xffff;
+  return crc & 0xffff;
+}
+
+//modified version of nxdn_deperm_facch1 -- this one for V/D Type 2 CC DCH (100 dibit version)
+int ysf_conv_dch2 (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t input[])
+{
+
+  int i, j, k, err;
+  uint8_t s0, s1;
+  uint8_t trellis_buf[100];
+  uint8_t temp[210];
+  uint8_t m_data[100];
+  uint8_t bits[210];
+  memset (trellis_buf, 0, sizeof(trellis_buf));
+  memset (temp, 0, sizeof (temp));
+  memset (m_data, 0, sizeof (m_data));
+  memset (bits, 0, sizeof(bits));
+  err = 0;
+
+  //dibit de-interleave block length M = 9 dibits and depth N = 20
+  uint8_t buf[100];
+  memset (buf, 0, sizeof(buf));
+  for (i=0; i<20; i++) {
+		for (j=0; j<5; j++) {
+			buf[j+(i*5)] = input[i+(j*20)];
+		}
+	}
+
+  k = 0;
+  //convert dibits to bits
+  for (i = 0; i < 100; i++)
+  {
+    bits[k++] = (buf[i] >> 1) & 1;
+    bits[k++] = (buf[i] >> 0) & 1;
+  }
+
+  //setup for the convolutional decoder
+  for (i = 0; i < 200; i++)
+    temp[i] = bits[i] << 1;
+
+  CNXDNConvolution_start();
+  for (i = 0; i < 100; i++)
+  {
+    s0 = temp[(2*i)+0];
+    s1 = temp[(2*i)+1];
+
+    CNXDNConvolution_decode(s0, s1);
+  }
+
+  CNXDNConvolution_chainback(m_data, 96);
+
+  //96/8 = 12, last 4 (96-100) are trailing zeroes
+  for(i = 0; i < 12; i++) 
+  {
+    trellis_buf[(i*8)+0] = (m_data[i] >> 7) & 1;
+    trellis_buf[(i*8)+1] = (m_data[i] >> 6) & 1;
+    trellis_buf[(i*8)+2] = (m_data[i] >> 5) & 1;
+    trellis_buf[(i*8)+3] = (m_data[i] >> 4) & 1;
+    trellis_buf[(i*8)+4] = (m_data[i] >> 3) & 1;
+    trellis_buf[(i*8)+5] = (m_data[i] >> 2) & 1;
+    trellis_buf[(i*8)+6] = (m_data[i] >> 1) & 1;
+    trellis_buf[(i*8)+7] = (m_data[i] >> 0) & 1;
+  }
+
+  uint16_t crc = crc16ysf(trellis_buf, 96);
+  if (crc != 0) err = -2;	// crc failure
+
+  for (i = 0; i < 80; i++)
+    trellis_buf[i] = trellis_buf[i] ^ pn95[i];
+
+  //reload after de-whitening
+  memset (m_data, 0, sizeof (m_data));
+  for (i = 0; i < 12; i++)
+    m_data[i] = (uint8_t)ConvertBitIntoBytes(&trellis_buf[i*8], 8);
+
+  //decode the callsign, etc, found in the DCH when no errors
+  if (err == 0)
+    ysf_dch_decode2 (opts, state, bn, bt, fn, ft, err, trellis_buf);
+
+  if (opts->payload == 1)
+	{
+    fprintf (stderr, "\n ");
+		fprintf (stderr, "DCH2: ");
+		for (i = 0; i < 12; i++)
+		{
+			fprintf (stderr, "[%02X]", m_data[i]); 
+		}
+		if (crc != 0)
+		{
+			fprintf (stderr, "%s", KRED);
+			fprintf (stderr, " (CRC ERR)");
+			fprintf (stderr, "%s", KNRM);
+		}
+    fprintf (stderr, " ");
+	}
+
+	return err;
+}
+
+//modified version of nxdn_deperm_facch1 -- this one for Full Rate, Type 1 CC, Headers and Terminators DCH (180 dibit version)
+int ysf_conv_dch (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t input[])
+{
+  int i, j, k, err;
+  uint8_t s0, s1;
+  uint8_t trellis_buf[190];
+  uint8_t temp[370];
+  uint8_t m_data[100];
+  uint8_t bits[370];
+  memset (trellis_buf, 0, sizeof(trellis_buf));
+  memset (temp, 0, sizeof (temp));
+  memset (m_data, 0, sizeof (m_data));
+  memset (bits, 0, sizeof(bits));
+  err = 0;
+
+  //dibit de-interleave block length M = 9 dibits and depth N = 20
+  uint8_t buf[180];
+  memset (buf, 0, sizeof(buf));
+  for (i=0; i<20; i++) { //20*9 = 180
+		for (j=0; j<9; j++) { 
+			buf[j+(i*9)] = input[i+(j*20)];
+		}
+	}
+
+  k = 0;
+  //convert dibits to bits
+  for (i = 0; i < 180; i++)
+  {
+    bits[k++] = (buf[i] >> 1) & 1;
+    bits[k++] = (buf[i] >> 0) & 1;
+  }
+
+  //setup for the convolutional decoder
+  for (i = 0; i < 360; i++)
+    temp[i] = bits[i] << 1;
+
+  CNXDNConvolution_start();
+  for (i = 0; i < 180; i++)
+  {
+    s0 = temp[(2*i)+0];
+    s1 = temp[(2*i)+1];
+
+    CNXDNConvolution_decode(s0, s1);
+  }
+
+  CNXDNConvolution_chainback(m_data, 176);
+
+  //176/8 = 22, last 4 (176-180) are trailing zeroes
+  for(i = 0; i < 22; i++) 
+  {
+    trellis_buf[(i*8)+0] = (m_data[i] >> 7) & 1;
+    trellis_buf[(i*8)+1] = (m_data[i] >> 6) & 1;
+    trellis_buf[(i*8)+2] = (m_data[i] >> 5) & 1;
+    trellis_buf[(i*8)+3] = (m_data[i] >> 4) & 1;
+    trellis_buf[(i*8)+4] = (m_data[i] >> 3) & 1;
+    trellis_buf[(i*8)+5] = (m_data[i] >> 2) & 1;
+    trellis_buf[(i*8)+6] = (m_data[i] >> 1) & 1;
+    trellis_buf[(i*8)+7] = (m_data[i] >> 0) & 1;
+  }
+
+  uint16_t crc = crc16ysf(trellis_buf, 176);
+  if (crc != 0) err = -2;	// crc failure
+
+  for (i = 0; i < 160; i++)
+    trellis_buf[i] = trellis_buf[i] ^ pn95[i];
+
+  //reload after de-whitening
+  memset (m_data, 0, sizeof (m_data));
+  for (i = 0; i < 22; i++)
+    m_data[i] = (uint8_t)ConvertBitIntoBytes(&trellis_buf[i*8], 8);
+
+  //decode the callsign, etc, found in the DCH when no errors
+  if (err == 0)
+    ysf_dch_decode (opts, state, bn, bt, fn, ft, err, trellis_buf);
+
+  if (opts->payload == 1)
+	{
+    fprintf (stderr, "\n ");
+		fprintf (stderr, "DCH1: ");
+		for (i = 0; i < 22; i++)
+		{
+			fprintf (stderr, "[%02X]", m_data[i]); 
+		}
+		if (crc != 0)
+		{
+			fprintf (stderr, "%s", KRED);
+			fprintf (stderr, " (CRC ERR)");
+			fprintf (stderr, "%s", KNRM);
+		}
+    fprintf (stderr, " ");
+	}
+
+	return err;
+}
+
+//modified version of nxdn_deperm_facch1
+int ysf_conv_fich (uint8_t input[], uint8_t dest[32])
+{
+  int i, j, k, err;
+  uint8_t s0, s1;
+  uint8_t trellis_buf[100];
+  uint8_t temp[210];
+  uint8_t m_data[100];
+  uint8_t bits[210];
+  memset (trellis_buf, 0, sizeof(trellis_buf));
+  memset (temp, 0, sizeof (temp));
+  memset (m_data, 0, sizeof (m_data));
+  memset (bits, 0, sizeof(bits));
+  err = 0;
+
+  //dibit de-interleave block length M = 5 dibits and depth N = 10
+  uint8_t buf[100];
+  memset (buf, 0, sizeof(buf));
+  for (i=0; i<20; i++) {
+		for (j=0; j<5; j++) {
+			buf[j+(i*5)] = input[i+(j*20)];
+		}
+	}
+
+  k = 0;
+  //convert dibits to bits
+  for (i = 0; i < 100; i++)
+  {
+    bits[k++] = (buf[i] >> 1) & 1;
+    bits[k++] = (buf[i] >> 0) & 1;
+  }
+
+  //setup for the convolutional decoder
+  for (i = 0; i < 200; i++) //192
+    temp[i] = bits[i] << 1;
+
+  CNXDNConvolution_start();
+  for (i = 0; i < 100; i++)
+  {
+    s0 = temp[(2*i)+0];
+    s1 = temp[(2*i)+1];
+
+    CNXDNConvolution_decode(s0, s1);
+  }
+
+  CNXDNConvolution_chainback(m_data, 96);
+
+  //96/8 = 12, last 4 (96-100) are trailing zeroes
+  for(i = 0; i < 12; i++) 
+  {
+    trellis_buf[(i*8)+0] = (m_data[i] >> 7) & 1;
+    trellis_buf[(i*8)+1] = (m_data[i] >> 6) & 1;
+    trellis_buf[(i*8)+2] = (m_data[i] >> 5) & 1;
+    trellis_buf[(i*8)+3] = (m_data[i] >> 4) & 1;
+    trellis_buf[(i*8)+4] = (m_data[i] >> 3) & 1;
+    trellis_buf[(i*8)+5] = (m_data[i] >> 2) & 1;
+    trellis_buf[(i*8)+6] = (m_data[i] >> 1) & 1;
+    trellis_buf[(i*8)+7] = (m_data[i] >> 0) & 1;
+  }
+
+  uint8_t fich_bits[12*4];
+  char temp_b[24];
+  bool g[4];
+
+  // run golay 24_12 error correction
+  for (i = 0; i < 4; i++)
+  {
+    memset (temp, 0, sizeof(temp_b));
+    g[i] = FALSE;
+
+    for (j = 0; j < 24; j++)
+      temp_b[j] = (char) trellis_buf[(i*24)+j];
+
+    g[i] = Golay_24_12_decode(temp_b);
+    if(g[i] == FALSE) err = -1;
+
+    for (j = 0; j < 24; j++)
+      trellis_buf[(i*24)+j] = (uint8_t) temp_b[j];
+  }
+
+  //load corrected bits
+  for (i = 0; i < 12; i++)
+  {
+    fich_bits[(12*0)+i] = trellis_buf[i+0];
+    fich_bits[(12*1)+i] = trellis_buf[i+24];
+    fich_bits[(12*2)+i] = trellis_buf[i+48];
+    fich_bits[(12*3)+i] = trellis_buf[i+72];
+  }
+
+  uint16_t crc = crc16ysf(fich_bits, 48);
+  if (crc != 0) err = -2;	// crc failure
+
+  memset (m_data, 0, sizeof (m_data));
+  for (i = 0; i < 12; i++)
+    m_data[i] = (uint8_t)ConvertBitIntoBytes(&trellis_buf[i*8], 8);
+
+  //debug output
+  // if (1 == 1)
+	// {
+	// 	fprintf (stderr, "FICH: ");
+	// 	for (i = 0; i < 12; i++)
+	// 	{
+	// 		fprintf (stderr, "[%02X]", m_data[i]); 
+	// 	}
+	// 	if (crc != 0)
+	// 	{
+	// 		fprintf (stderr, "%s", KRED);
+	// 		fprintf (stderr, " (CRC ERR)");
+	// 		fprintf (stderr, "%s", KNRM);
+	// 	}
+  //   fprintf (stderr, " ");
+	// }
+
+	memcpy(dest, fich_bits, 32); //copy minus the crc16
+	return err;
+}
+
+//YSF pn95 scrambler/whitening bit generator with seed 111001001 
+void pn95_lfsr() //test to see if this generates the correct bits now
+{
+  int i;
+  int lfsr;
+  int pN[513];
+  memset (pN, 0, sizeof(pN));
+  int bit = 0;
+
+  lfsr = 0x1c9; //111001001 initial value
+  fprintf (stderr, "\n pN95 = { \n");
+  for (i = 0; i < 512; i++)
+  {
+    pN[i] = lfsr & 0x1;
+    bit = ( (lfsr >> 4) ^ (lfsr >> 0) ) & 1;
+    lfsr =  ( (lfsr >> 1 ) | (bit << 9) ); //9, or 8
+    if (i % 8 == 0) fprintf (stderr, "\n");
+    fprintf (stderr, " %d,", pN[i]);
+  }
+  fprintf (stderr, "};");
+
+}
+
+void fr_demodulation(uint8_t out[], uint8_t in[], uint16_t n, uint32_t seed, uint8_t shift)
+{
+  uint32_t v = seed << shift;
+  // fprintf (stderr, "SEED = %X", seed);
+  for (uint16_t i=0; i<n; i++)
+  {
+      v = ((v * 173) + 13849) & 0xffff; //is this the same as below?
+      // v = (173 * v) + 13849 - (65536 * (((173 * v) + 13849) / 65536)); //from mbe_demodulateImbe7200x4400Data
+      out[i] = in[i] ^ (v >> 15);
+  }
+}
+
+void ysf_ehr (dsd_opts * opts, dsd_state * state, uint8_t dbuf[180], int start, int stop )
+{
+  int i, j, k, dibit;
+  char ambe_fr[4][24];
+  memset (ambe_fr, 0, sizeof(ambe_fr));
+
+  unsigned char *pr;
   const int *w, *x, *y, *z;
-  char ambe_fr[8][4][24];
-  unsigned char storage[8][4][24]; //may expand later
-  unsigned char discard[460]; //just set up for now to hold random dibit grabs with nothing to do but skip them
-  unsigned char vch[4][36]; //correct size array for 4*32 dibit VD2 VCH?
-  unsigned char fich[200]; //store as bits after deinterleaving
-  unsigned char fichraw[100];
-  unsigned char fichdibits[100]; //deinterleaved fich dibits
-  unsigned char fichbytes[26];
-  unsigned int fi = 0;
-  unsigned int cs = 0;
-  unsigned int cm = 0;
-  unsigned int bn = 0;
-  unsigned int bt = 0;
-  unsigned int fn = 0;
-  unsigned int ft = 0;
-  unsigned int mr = 0;
-  unsigned int ip = 0;
-  unsigned int dt = 0; //DT, 2 bytes (according to manual, but has to be two bits)
-  unsigned int sq = 0;
-  unsigned int sc = 0;
-  int vd1 = 1;
-  int vd2 = 0;
-  unsigned int msbI = 0;
-  unsigned int lsbI = 0;
-  unsigned char vd2BitsRaw[104];
-  opts->inverted_ysf = 0; //here for testing purposes, move to main later
-  for (i = 0; i < 100; i++) //100 dibits for fich
-  {
-    dibit = getDibit (opts, state);
 
-    if (opts->inverted_ysf == 1) //opts->inverted_ysf == 1
-    {
-      dibit = (dibit ^ 2);
-    }
-    fichraw[i] = dibit; //raw storage for debug
-    fichdibits[fichInterleave[i]] = dibit; //sort into proper order
-    //fich[i*2]   = (1 & (dibit >> 1));   // bit 1
-    //fich[i*2+1] = (1 & dibit);          // bit 0
-    fich[i*2]   = (fichdibits[fichInterleave[i]] >> 1) & 1;
-    //fprintf (stderr, "%b", fich[i*2]);
-    fich[i*2+1] =  fichdibits[fichInterleave[i]]       & 1;
-    //fprintf (stderr, "%b", fich[i*2+1]);
-    if (i == 4)
-    {
-      //datatype = dibit;
-    }
-  }
-  //fprintf (stderr, "\nFICH BYTES = ");
-  for (i = 0; i < 25; i++) //bits to bytes
+  int st = state->synctype;
+  state->synctype = 28;
+
+  uint8_t b1, b2;
+
+  k = 0;
+
+  for (start; start < stop; start++)
   {
-    fichbytes[i] = 0; //initialize to see what isn't beign set
-    fichbytes[i] = ( (fich[i*8]   << 7) | (fich[i*8+1] << 6) | (fich[i*8+2] << 5) | (fich[i*8+3] << 4) |
-                     (fich[i*8+4] << 3) | (fich[i*8+5] << 2) | (fich[i*8+6] << 1) | (fich[i*8+7] << 0) );
-    //fprintf (stderr, "[%02X]", fichbytes[i]);
-  }
-  //fprintf (stderr, "\n");
-  //datatype = (fich[8] << 1) + fich[9];
-  dt = fichbytes[2] & 0x03;
-  for (i = 0; i < 2; i++)
-  {
-    //datatype << 1;
-    //datatype = datatype | fichraw[i+8];
-    //fprintf (stderr, "%02b", fichdibits[i+4]);
-    //fprintf (stderr, "%02b", fichdibits[i+11]);
-  }
-  //fprintf (stderr, "Datatype = %02b\n", dt);
-  //quick dirty VD1 method?
-  if (0 == 0) //dt == 0 for VD1
-  {
-   fprintf (stderr, "processYSF VD1 \n");
-   for (j = 0; j < 5; j++) //5 DCH and VCH
-   {
-    w = YSFrW;
-    x = YSFrX;
-    y = YSFrY;
-    z = YSFrZ;
+    w = YnW;
+    x = YnX;
+    y = YnY;
+    z = YnZ;
     k = 0;
+
+    //debug
+    // fprintf (stderr, " DBUF = ");
+
     for (i = 0; i < 36; i++)
     {
-      dibit = getDibit (opts, state);
 
-      if (opts->inverted_ysf == 1) //opts->inverted_ysf == 1
-      {
-        dibit = (dibit ^ 2);
-      }
+      //debug
+      // fprintf (stderr, "%d", dbuf[(start*36)+i]);
 
-      storage[j][*w][*x] = (1 & (dibit >> 1));   // bit 1
-      storage[j][*y][*z] = (1 & dibit);          // bit 0
+      b1 = dbuf[(start*36)+i] >> 1;
+      b2 = dbuf[(start*36)+i] & 1;
 
-    }
-
-
-
-      //AMBE VCH
-    for (i = 0; i < 36; i++)
-    {
-      dibit = getDibit (opts, state);
-
-      if (opts->inverted_ysf == 1) //opts->inverted_ysf == 1
-      {
-        dibit = (dibit ^ 2);
-      }
-
-      ambe_fr[j][*w][*x] = (1 & (dibit >> 1));   // bit 1
-      ambe_fr[j][*y][*z] = (1 & dibit);          // bit 0
+      //should all be loaded back to back
+      ambe_fr[*w][*x] = (char)b1;
+      ambe_fr[*y][*z] = (char)b2;
+  
       w++;
       x++;
       y++;
       z++;
+
     }
-    //processMbeFrame (opts, state, NULL, ambe_fr[j], NULL);
-  } //end j < 4 loop
- } //end VD1
- //move processMbeFrame to outside of dibit loop to prevent slip
- for (j = 0; j < 5; j++)
- {
-   //processMbeFrame (opts, state, NULL, ambe_fr[j], NULL);
- }
- //VD2 method
- if (0 == 3) //dt == 3
- {
-   fprintf (stderr, "processYSF VD2 \n");
-   for (j = 0; j < 4; j++)
-   {
-     //VCH[j] and VeCH[j]
-     for (i = 0; i < 20; i++) //32?
-     {
-       dibit = getDibit (opts, state);
 
-       if (opts->inverted_ysf == 1) //opts->inverted_ysf == 1
-       {
-         dibit = (dibit ^ 2);
-       }
-       //collect dibits into array for processing
-       vch[j][i] = dibit;
-       w = YSFrW;
-       x = YSFrX;
-       y = YSFrY;
-       z = YSFrZ;
-       msbI = vd2Interleave[(j+1)*i]; //don't this this is remotely correct, really could use the manual right about now
-       lsbI = vd2Interleave[(j+1)*i+1];
-       vd2BitsRaw[msbI] = ((vch[j][i] >> 1) & 1);
-       vd2BitsRaw[lsbI] = (vch[j][i] & 1);
-   } // VCH[j]
-   //DCH[j]
-   for (i = 0; i < 20; i++) //32?
-   {
-     dibit = getDibit (opts, state);
+    processMbeFrame (opts, state, NULL, ambe_fr, NULL);
 
-     if (opts->inverted_ysf == 1) //opts->inverted_ysf == 1
-     {
-       dibit = (dibit ^ 2);
-     }
-     discard[i] = dibit;
-   } //end DCH[j]
- } //end for j loop
+  }
+  
+  if (opts->payload == 1)
+  {
+    fprintf(stderr, "\n");
+  }
+  
+  state->synctype = st;
+}
 
- } //end VD2
+void processYSF(dsd_opts * opts, dsd_state * state)
+{
+  static uint8_t last_dt, last_fi; //if we can't get a good dt and fi, then just use the last one instead
+  int i, j, k, l, err, vstart, vstop, dstart, dstop; //start stops are for Full Rate when we might have some portions of Data present in the Comm Channel
+  int dibit;
+  const int *w, *x, *y, *z;
+  uint8_t fichdibits[100]; //fich dibits
+  uint8_t fichrawdibits[100];
+  uint8_t fichrawbits[200];
+  uint8_t fich_d_bits[100];
+  uint8_t fich_decode[32];
+  memset (fichdibits, 0, sizeof(fichdibits));
+  memset (fichrawdibits, 0, sizeof(fichrawdibits));
+  memset (fichrawbits, 0, sizeof(fichrawbits));
+  memset (fich_d_bits, 0, sizeof(fich_d_bits));
+  memset (fich_decode, 0, sizeof(fich_decode));
+  char ambe_fr[4][24];
+  memset (ambe_fr, 0, sizeof(ambe_fr));
+  char imbe_fr[8][23];
+  memset (imbe_fr, 0, sizeof(imbe_fr));
+  uint8_t b1, b2, msb, lsb;
+  b1 = b2 = msb = lsb = vstart = vstop = dstart = dstop = 0;
+
+  //fich information
+  uint8_t fi = 9; //Header, Communications, or Terminator
+  uint8_t cs = 9; //Type of Callsign
+  uint8_t cm = 9; //Type of Call
+  uint8_t bn = 9; //block number
+  uint8_t bt = 9; //block total
+  uint8_t fn = 9; //frame number
+  uint8_t ft = 9; //frame total
+  uint8_t mr = 9; //message path
+  uint8_t vp = 9; //VoIP path
+  uint8_t dt = 9; //Data Type -- type 1 (EHR no VeCH); type 2 (EHR w/ VeCH); type 3 (EFR)
+  uint8_t st = 9; //SQL Type
+  uint8_t sc = 69; //SQL Code
+
+  // pn95lfsr(); //run to print the bits for the DCH/VeCH whitening array
+
+  //FICH you
+  for (i = 0; i < 100; i++)
+    fichrawdibits[i] = getDibit(opts, state);
+
+  //from nxdn_deperm_facch1 w/ nxdn convolutional decoder
+  err = ysf_conv_fich (fichrawdibits, fich_decode);
+
+  //seems to still work better by just allowing all decoding, even with errs present
+  if (err == 0)
+  {
+    fi = (uint8_t)ConvertBitIntoBytes(&fich_decode[0], 2);
+    cs = (uint8_t)ConvertBitIntoBytes(&fich_decode[2], 2);
+    cm = (uint8_t)ConvertBitIntoBytes(&fich_decode[4], 2);
+    bn = (uint8_t)ConvertBitIntoBytes(&fich_decode[6], 2);
+    bt = (uint8_t)ConvertBitIntoBytes(&fich_decode[8], 2);
+    fn = (uint8_t)ConvertBitIntoBytes(&fich_decode[10], 3);
+    ft = (uint8_t)ConvertBitIntoBytes(&fich_decode[13], 3);
+    mr = (uint8_t)ConvertBitIntoBytes(&fich_decode[18], 3);
+    vp = fich_decode[21];
+    dt = (uint8_t)ConvertBitIntoBytes(&fich_decode[22], 2);
+    st = fich_decode[24];
+    sc = (uint8_t)ConvertBitIntoBytes(&fich_decode[25], 7);
+
+    state->ysf_dt = dt;
+    state->ysf_fi = fi;
+    state->ysf_cm = cm;
+
+    last_dt = dt;
+    last_fi = fi;
+  }
+  // else goto END;
+  else
+  {
+    dt = last_dt;
+    fi = last_fi;
+  }
+
+  //print some useful decoded shit
+  if (fi == 0) fprintf (stderr, "HC ");
+  if (fi == 1) fprintf (stderr, "CC ");
+  if (fi == 2) fprintf (stderr, "TC ");
+  if (fi == 3) fprintf (stderr, "XX "); //Test
+
+  if (dt == 0) fprintf (stderr, "V/D1 ");
+  if (dt == 1) fprintf (stderr, "DATA ");
+  if (dt == 2) fprintf (stderr, "V/D2 ");
+  if (dt == 3) fprintf (stderr, "VCHF ");
+
+  if (cm == 0) fprintf (stderr, "Group/CQ ");
+  if (cm == 3) fprintf (stderr, "Private  ");
+  if (cm == 1) fprintf (stderr, "Reserved ");
+  if (cm == 2) fprintf (stderr, "Reserved ");
+
+  if (mr == 0) fprintf (stderr, "Direct Wave ");
+  if (mr == 1) fprintf (stderr, "Downlink (BUSY) ");
+  if (mr == 2) fprintf (stderr, "Downlink (FREE) ");
+
+  if (vp == 1) fprintf (stderr, "Local (Simplex) ");
+  if (vp == 0) fprintf (stderr, "Internet (Rep) ");
+
+  // if (st && sc != 69) fprintf (stderr, "SQL ");
+  // if (st && sc != 69) fprintf (stderr, "CODE: %X ", sc);
+
+  //print out current block numbering and frame numbering
+  // fprintf (stderr, "BN: %d BT: %d FN: %d FT: %d ", bn, bt, fn, ft);
+
+  //simplified version
+  if (ft != 0) //if frame total is greater than 0
+    fprintf (stderr, "FN:%d-%d ", fn, ft);
+
+  if (opts->payload == 1)
+  {
+    fprintf (stderr, " FICH: ");
+    for (int i = 0; i < 4; i++)
+      fprintf (stderr, "[%02X]", (uint8_t)ConvertBitIntoBytes(&fich_decode[i*8], 8)); 
+  }
+
+  if (err != 0)
+  {
+    fprintf (stderr, "%s", KRED);
+    if (err == -1)
+      fprintf (stderr, "(FEC ERR)");
+    if (err == -2)
+      fprintf (stderr, "(CRC ERR)");
+    fprintf (stderr, "%s", KNRM);
+  }
+
+  // if (fi == 0) fprintf (stderr, "%s", KGRN); //HC Channel
+  // else if (fi == 2) fprintf (stderr, "%s", KRED); //TC Channel
+  // else if (dt == 0 || dt == 2) fprintf (stderr, "%s", KGRN); //Voice CC
+  // else fprintf (stderr, "%s", KCYN); //Data
+
+  //DCH and VCH
+  uint8_t dbuf[190]; //data dibit buffer
+  uint8_t vbuf[190]; //voice dibit buffer
+  uint8_t vech[255]; //VeCH dibit buffer
+  uint8_t temp[512]; ///temp space for manipulating VeCH into VBUF
+
+  char ambe_d[49];
+
+  memset (vbuf, 0, sizeof(vbuf));
+  memset (dbuf, 0, sizeof(dbuf));
+  memset (vech, 0, sizeof(vech));
+  memset (temp, 0, sizeof(temp));
+
+  //bit buffers
+  // uint8_t dch_bits[6][72];
+  uint8_t dch_bits[160];
+  uint8_t vch_bits[6][72];
+  uint8_t vech_bits[104];
+  uint8_t buf[100];
+
+  memset (dch_bits, 0, sizeof(dch_bits));
+  memset (vch_bits, 0, sizeof(vch_bits));
+  memset (vech_bits, 0, sizeof(vech_bits));
+
+  // V/D Mode Type 1 (no VeCH)
+  if (fi == 1 && dt == 0)
+  {
+    //need to double check all this if I can get a sample of it
+    for (i = 0; i < 5; i++) //5 on EHR Type 1 (no VeCH)
+    {
+
+      // DCH First
+      for (j = 0; j < 36; j++)
+        dbuf[(i*36)+j] = getDibit(opts, state);
+
+
+      //VCH Second
+      for (j = 0; j < 36; j++)
+        vbuf[(i*36)+j] = getDibit(opts, state);
+
+    }
+
+    // send VCH to ehr voice handler -- buffer run
+    ysf_ehr (opts, state, vbuf, 0, 4);
+
+  }
+  
+
+  /*
+    In the case of V/D mode type 2, error correction for the purpose of improving the connectivity
+    of a weak electric field is carried out (separately from the error correction function of the voice
+    encoder).
+  */
+
+  // V/D Mode Type 2 (w/ VeCH and bullshit ECC)
+  if (fi == 1 && dt == 2)
+  {
+    int d = 0;
+    for (i = 0; i < 5; i++)
+    {
+      //DCH
+      for (j = 0; j < 20; j++) 
+        dbuf[d++] = getDibit(opts, state);
+
+      //VeCH
+      k = 0; l = 0;
+      memset (vech_bits, 0, sizeof(vech_bits));
+      memset (temp, 0, sizeof(temp));
+
+      state->errs  = 0;
+      state->errs2 = 0;
+
+      for (j = 0; j < 52; j++)
+      {
+        dibit = getDibit(opts, state);
+
+        //deinterleave and de-whiten VeCH (from DSDcc)
+        b1 = (dibit >> 1) & 1;
+        b2 = (dibit >> 0) & 1;
+
+        msb = vd2Interleave[k]; k++;
+        lsb = vd2Interleave[k]; k++;
+
+        vech_bits[msb] = b1 ^ pn95[msb];
+        vech_bits[lsb] = b2 ^ pn95[lsb];
+
+      }
+
+      uint8_t majority[8] = {0,0,0,1,0,1,1,1};
+      //I have no idea how this is considered to be a form of forward error correction
+      l = 0;
+      for (j = 0; j < 81; j++)
+      {
+        //OP25 majority method with table
+        if (j % 3 == 2)
+        {
+          //I still have no idea what the method of this is...hamming table?
+          temp[l] = majority[ (vech_bits[j-2] << 2) | (vech_bits[j-1] << 1) | vech_bits[j] ];
+          l++;
+        }
+      }
+
+      for (j = 0; j < 22; j++)
+        temp[j+27] = vech_bits[j+81];
+      
+      for (j = 0; j < 49; j++)
+        ambe_d[j] = temp[j]; //(char) 
+
+      state->errs2 = vech_bits[103]; //should be zero, but if it isn't, then its an error
+
+      mbe_processAmbe2450Dataf (state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
+                                ambe_d, state->cur_mp, state->prev_mp, state->prev_mp_enhanced, opts->uvquality);
+
+      if (opts->payload == 1)
+        PrintAMBEData (opts, state, ambe_d);
+
+      processAudio(opts, state);
+      playSynthesizedVoice (opts, state);
+
+    }
+
+    //process completed DCH
+    ysf_conv_dch2 (opts, state, bn, bt, fn, ft, dbuf);
+
+  }
+  
+  //Full-Rate AMBE+2 EFR (Supposed to work with IMBE?)
+  uint8_t imbe_vch[144];
+  memset (imbe_vch, 0, sizeof(imbe_vch));
+  uint8_t pNfr[144]; //144
+  uint32_t seed; //for fr_scramble from gr-ysf
+
+  uint8_t imbe_raw[144];
+  char imbe_d[88];
+
+  //this is to setup and use the mbe_golay2312 (in, out); function
+  char in[23];
+  char out[23];
+  //hamming on u4-7
+  char hin[15];
+  char hout[15];
+
+  //Voice FR Mode (Type 3 AMBE+2 Full Rate)
+  if (fi == 1 && dt == 3)
+  {
+
+    /*
+      Under this pattern, when the initial HC and initial CC (Sub header (CSD3)) cannot be received, the Call sign information can not be obtained.
+      No CSD3 information can be obtained from other frames except the FT=1/FN=0 frame.
+
+      What we need to do is look at the frame, and determine if its a CSD3 by the ft == 1 and fn == 0 and set an appropirate start/stop value here
+    */
+
+    if (ft == 1 && fn == 0)
+    {
+      dstart = 0;
+      dstop = 6; //5 DCH and 1 reserved bank
+      vstart = 0;
+      vstop = 2; //only 2 VCH in the CSD3 Sub Header
+    }
+    else
+    {
+      dstart = 0;
+      dstop = 0;
+      vstart = 0;
+      vstop = 5;
+    }
+
+    for (dstart; dstart < dstop; dstart++)
+    {
+      //get dibits for CSD3 Sub Header DCH -- double check this
+      for (j = 0; j < 36; j++) //dbufFR[2][190]
+      {
+        if (dstart != 5) //only want the first 5
+          dbuf[(dstart*36)+j] = getDibit(opts, state);
+        else skipDibit(opts, state, 1); //skip the reserved bank
+      } 
+        
+
+    }
+
+    for (vstart; vstart < vstop; vstart++)
+    {
+      
+      //init a bunch of stuff
+      memset (imbe_raw, 0, sizeof(imbe_raw));
+      memset (imbe_d, 0, sizeof(imbe_d));
+      memset (imbe_fr, 0, sizeof(imbe_fr));
+      memset (pNfr, 0, sizeof(pNfr));
+
+      memset (in, 0, sizeof(in));
+      memset (out, 0, sizeof(out));
+      memset (hin, 0, sizeof(hin));
+      memset (hout, 0, sizeof(hout));
+
+      for (j = 0; j < 72; j++)
+      {
+        dibit = getDibit(opts, state);
+
+        b1 = (dibit >> 1) & 1;
+        b2 = (dibit >> 0) & 1;
+
+        imbe_raw[(j*2)+0] = b1;
+        imbe_raw[(j*2)+1] = b2;
+
+      }
+
+      //de-interleave to vch bits
+      for (j = 0; j < 144; j++)
+        imbe_vch[j] = imbe_raw[fr_interleave[j]];
+
+      //load the first 23 bits (u0) into a temp buffer for ecc
+      for (j = 0; j < 23; j++)
+        in[j] = imbe_vch[j];
+
+      //Run Golay 23,12 on u0 so we get a good demodulation pn sequence
+      state->errs = mbe_golay2312 (in, out);
+
+      //reload u0 back into imbe_vch buffer
+      for (j = 0; j < 23; j++)
+        imbe_vch[j] = out[j];
+
+      //obtain a seed value to feed the lfsr to demodulate the rest of this frame
+      seed = 45;
+      for (j = 0; j < 12; j++)
+      {
+        seed = seed << 1;
+        seed = seed | imbe_vch[j];
+      }
+
+      //NOTE: Perhaps AMBE+2 FR and IMBE just use a different demod PN sequence?
+
+      //demod/descramble with pn sequence
+      fr_demodulation  (imbe_vch+23, imbe_vch+23, 144-23-7, seed, 4);
+
+      //do manual error correction here on the rest
+      state->errs2 = 0;
+      for (k = 1; k < 4; k++)
+      {
+        memset (in, 0, sizeof(in));
+        memset (out, 0, sizeof(out));
+
+        //load the next 23 bits (u1, u2, u3) into a temp buffer for ecc
+        for (j = 0; j < 23; j++)
+          in[j] = imbe_vch[(k*23)+j]; //I think the FEC on u0 is incorrect in the interleave
+
+        //Run Golay 23,12 on u(k)
+        state->errs2 += mbe_golay2312 (in, out);
+
+        //reload u(k) back into imbe_vch buffer
+        for (j = 0; j < 23; j++)
+          imbe_vch[(k*23)+j] = out[j];
+      }
+
+      // for (k = 4; k < 7; k++)
+      // {
+      //   //TODO: hamming
+      // }
+
+      memset (imbe_raw, 0, sizeof(imbe_raw));
+
+      // FIXME: We should apply FEC here -- already working on it, chief
+      k = 0;
+      for(j =  0; j <  12; j++) imbe_raw[k++] = imbe_vch[j]; // u0
+      for(j = 23; j <  35; j++) imbe_raw[k++] = imbe_vch[j]; // u1
+      for(j = 46; j <  58; j++) imbe_raw[k++] = imbe_vch[j]; // u2
+      for(j = 69; j <  81; j++) imbe_raw[k++] = imbe_vch[j]; // u3
+      for(j = 92; j < 103; j++) imbe_raw[k++] = imbe_vch[j]; // u4
+      for(j =107; j < 118; j++) imbe_raw[k++] = imbe_vch[j]; // u5
+      for(j =122; j < 133; j++) imbe_raw[k++] = imbe_vch[j]; // u6
+      for(j =137; j < 144; j++) imbe_raw[k++] = imbe_vch[j]; // u7
+
+      mbe_processImbe4400Dataf (state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
+        imbe_raw, state->cur_mp, state->prev_mp, state->prev_mp_enhanced, opts->uvquality);
+
+      if (opts->payload == 1)
+        PrintIMBEData (opts, state, imbe_raw);
+
+      processAudio(opts, state);
+      playSynthesizedVoice (opts, state);
+
+    }
+
+    if (ft == 1 && fn == 0)
+    {
+      //process completed DCH -- use 2 for bn to switch CSD 3 info
+      ysf_conv_dch (opts, state, 2, bt, fn, ft, dbuf);
+    }
+  }
+
+  //full rate data
+  uint8_t dbufFR[2][180];
+  memset (dbufFR, 0, sizeof(dbufFR));
+  if (dt == 1 || fi == 0 || fi == 2)
+  {
+    for (i = 0; i < 10; i++)
+    {
+      for (j = 0; j < 36; j++)
+        dbufFR[i % 2][((i/2)*36)+j] = getDibit(opts, state);
+    }
+
+    //clear old txt data
+    // if (fi == 0) memset (state->ysf_txt, 0, sizeof(state->ysf_txt));
+
+    for (i = 0; i < 2; i++)
+    {
+      //process completed DCH -- use i to for bn to switch CSD1 and CSD2 on HC and TC
+      if (fi == 0 || fi == 2)
+        ysf_conv_dch (opts, state, i, bt, fn, ft, dbufFR[i]);
+      //using bn == 2 for full rate data and fn*2+1 for easier frame storage
+      else ysf_conv_dch (opts, state, 2, bt, fn*2+i, ft, dbufFR[i]);
+
+    }
+    
+  }
+
+  END:
+  // if (err != 0) skipDibit(opts, state, 360);
+
+  //ending line break
+  fprintf (stderr, "%s", KNRM);
+  fprintf (stderr, "\n");
 
 } //end processYSF

--- a/src/ysf.c
+++ b/src/ysf.c
@@ -357,10 +357,10 @@ int ysf_conv_dch2 (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, u
   uint8_t buf[100];
   memset (buf, 0, sizeof(buf));
   for (i=0; i<20; i++) {
-		for (j=0; j<5; j++) {
-			buf[j+(i*5)] = input[i+(j*20)];
-		}
-	}
+    for (j=0; j<5; j++) {
+      buf[j+(i*5)] = input[i+(j*20)];
+    }
+  }
 
   k = 0;
   //convert dibits to bits
@@ -414,21 +414,21 @@ int ysf_conv_dch2 (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, u
     ysf_dch_decode2 (opts, state, bn, bt, fn, ft, err, trellis_buf);
 
   if (opts->payload == 1)
-	{
+  {
     fprintf (stderr, "\n ");
-		fprintf (stderr, "DCH2: ");
-		for (i = 0; i < 12; i++)
-		{
-			fprintf (stderr, "[%02X]", m_data[i]); 
-		}
-		if (crc != 0)
-		{
-			fprintf (stderr, "%s", KRED);
-			fprintf (stderr, " (CRC ERR)");
-			fprintf (stderr, "%s", KNRM);
-		}
+    fprintf (stderr, "DCH2: ");
+    for (i = 0; i < 12; i++)
+    {
+      fprintf (stderr, "[%02X]", m_data[i]); 
+    }
+    if (crc != 0)
+    {
+      fprintf (stderr, "%s", KRED);
+      fprintf (stderr, " (CRC ERR)");
+      fprintf (stderr, "%s", KNRM);
+    }
     fprintf (stderr, " ");
-	}
+  }
 
 	return err;
 }
@@ -452,10 +452,10 @@ int ysf_conv_dch (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, ui
   uint8_t buf[180];
   memset (buf, 0, sizeof(buf));
   for (i=0; i<20; i++) { //20*9 = 180
-		for (j=0; j<9; j++) { 
-			buf[j+(i*9)] = input[i+(j*20)];
-		}
-	}
+    for (j=0; j<9; j++) { 
+      buf[j+(i*9)] = input[i+(j*20)];
+    }
+  }
 
   k = 0;
   //convert dibits to bits
@@ -509,21 +509,21 @@ int ysf_conv_dch (dsd_opts * opts, dsd_state * state, uint8_t bn, uint8_t bt, ui
     ysf_dch_decode (opts, state, bn, bt, fn, ft, err, trellis_buf);
 
   if (opts->payload == 1)
-	{
+  {
     fprintf (stderr, "\n ");
-		fprintf (stderr, "DCH1: ");
-		for (i = 0; i < 22; i++)
-		{
-			fprintf (stderr, "[%02X]", m_data[i]); 
-		}
-		if (crc != 0)
-		{
-			fprintf (stderr, "%s", KRED);
-			fprintf (stderr, " (CRC ERR)");
-			fprintf (stderr, "%s", KNRM);
-		}
+    fprintf (stderr, "DCH1: ");
+    for (i = 0; i < 22; i++)
+    {
+      fprintf (stderr, "[%02X]", m_data[i]); 
+    }
+    if (crc != 0)
+    {
+      fprintf (stderr, "%s", KRED);
+      fprintf (stderr, " (CRC ERR)");
+      fprintf (stderr, "%s", KNRM);
+    }
     fprintf (stderr, " ");
-	}
+  }
 
 	return err;
 }
@@ -547,10 +547,10 @@ int ysf_conv_fich (uint8_t input[], uint8_t dest[32])
   uint8_t buf[100];
   memset (buf, 0, sizeof(buf));
   for (i=0; i<20; i++) {
-		for (j=0; j<5; j++) {
-			buf[j+(i*5)] = input[i+(j*20)];
-		}
-	}
+    for (j=0; j<5; j++) {
+      buf[j+(i*5)] = input[i+(j*20)];
+    }
+  }
 
   k = 0;
   //convert dibits to bits
@@ -626,20 +626,20 @@ int ysf_conv_fich (uint8_t input[], uint8_t dest[32])
 
   //debug output
   // if (1 == 1)
-	// {
-	// 	fprintf (stderr, "FICH: ");
-	// 	for (i = 0; i < 12; i++)
-	// 	{
-	// 		fprintf (stderr, "[%02X]", m_data[i]); 
-	// 	}
-	// 	if (crc != 0)
-	// 	{
-	// 		fprintf (stderr, "%s", KRED);
-	// 		fprintf (stderr, " (CRC ERR)");
-	// 		fprintf (stderr, "%s", KNRM);
-	// 	}
+  // {
+  //   fprintf (stderr, "FICH: ");
+  //   for (i = 0; i < 12; i++)
+  //   {
+  //     fprintf (stderr, "[%02X]", m_data[i]); 
+  //   }
+  //   if (crc != 0)
+  //   {
+  //     fprintf (stderr, "%s", KRED);
+  //     fprintf (stderr, " (CRC ERR)");
+  //     fprintf (stderr, "%s", KNRM);
+  //   }
   //   fprintf (stderr, " ");
-	// }
+  // }
 
 	memcpy(dest, fich_bits, 32); //copy minus the crc16
 	return err;
@@ -674,9 +674,9 @@ void fr_demodulation(uint8_t out[], uint8_t in[], uint16_t n, uint32_t seed, uin
   // fprintf (stderr, "SEED = %X", seed);
   for (uint16_t i=0; i<n; i++)
   {
-      v = ((v * 173) + 13849) & 0xffff; //is this the same as below?
-      // v = (173 * v) + 13849 - (65536 * (((173 * v) + 13849) / 65536)); //from mbe_demodulateImbe7200x4400Data
-      out[i] = in[i] ^ (v >> 15);
+    v = ((v * 173) + 13849) & 0xffff; //is this the same as below?
+    // v = (173 * v) + 13849 - (65536 * (((173 * v) + 13849) / 65536)); //from mbe_demodulateImbe7200x4400Data
+    out[i] = in[i] ^ (v >> 15);
   }
 }
 

--- a/src/ysf.c
+++ b/src/ysf.c
@@ -816,24 +816,25 @@ void processYSF(dsd_opts * opts, dsd_state * state)
 
   if (cm == 0) fprintf (stderr, "Group/CQ ");
   if (cm == 3) fprintf (stderr, "Private  ");
-  if (cm == 1) fprintf (stderr, "Reserved ");
-  if (cm == 2) fprintf (stderr, "Reserved ");
+  if (cm == 1) fprintf (stderr, "Res: 1   ");
+  if (cm == 2) fprintf (stderr, "Res: 2   ");
 
-  if (mr == 0) fprintf (stderr, "Direct Wave ");
-  if (mr == 1) fprintf (stderr, "Downlink (Busy) ");
-  if (mr == 2) fprintf (stderr, "Downlink (Free) ");
+  if (vp == 0) fprintf (stderr, "Local (Simplex) ");
+  if (vp == 1) fprintf (stderr, "Internet (Rep)  ");
 
-  if (vp == 1) fprintf (stderr, "Local (Simplex) ");
-  if (vp == 0) fprintf (stderr, "Internet (Rep) ");
+  if (mr == 0) fprintf (stderr, "(Direct Wave) ");
+  if (mr == 1) fprintf (stderr, "(Uplink Free) ");
+  if (mr == 2) fprintf (stderr, "(Uplink Busy) ");
+  if (mr > 2 && mr < 7) fprintf (stderr, "Res: %03d ", mr);
 
   if (st && sc != 69) fprintf (stderr, "SQL ");
-  if (st && sc != 69) fprintf (stderr, "CODE: %X ", sc);
+  if (st && sc != 69) fprintf (stderr, "CODE: %03d ", sc);
 
   //print out current block numbering and frame numbering
   // fprintf (stderr, "BN: %d BT: %d FN: %d FT: %d ", bn, bt, fn, ft);
 
   //simplified version
-  if (ft != 0) //if frame total is greater than 0
+  if (ft != 0 && err == 0) //if frame total is greater than 0
     fprintf (stderr, "FN:%d-%d ", fn, ft);
 
   if (opts->payload == 1)
@@ -846,6 +847,7 @@ void processYSF(dsd_opts * opts, dsd_state * state)
   if (err != 0)
   {
     fprintf (stderr, "%s", KRED);
+    fprintf (stderr, "FICH ");
     if (err == -1)
       fprintf (stderr, "(FEC ERR)");
     if (err == -2)
@@ -900,8 +902,11 @@ void processYSF(dsd_opts * opts, dsd_state * state)
 
     }
 
-    // send VCH to ehr voice handler -- buffer run
+    // send VCH to ehr voice handler
     ysf_ehr (opts, state, vbuf, 0, 4);
+
+    //send DCH to decoder
+    ysf_conv_dch (opts, state, bn, bt, fn, ft, dbuf);
 
   }
   


### PR DESCRIPTION
There are a lot of changes but most of them are trivial. I tried to preserve those variables with special meaning and which, kind of, document the code. Also, I added `-Wunused-but-set-variable` and `-Wunused-variable` flags in CMake. A good practice is to add `-Werror` at the same time but for the moment `ysf.c` and `trellis.cpp` are not ready for this and I don't want to mess with them.