### PR TITLE
Fix warnings related to unused variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 ADD_EXECUTABLE(dsd-fme ${SRCS} ${HEADERS})
 TARGET_LINK_LIBRARIES(dsd-fme ${LIBS})
 
+target_compile_options(dsd-fme PRIVATE -Wunused-but-set-variable -Wunused-variable)
+
 include(GNUInstallDirs)
 install(TARGETS dsd-fme DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/include/dsd.h
+++ b/include/dsd.h
@@ -74,6 +74,12 @@
 #include <locale.h>
 #include <ncurses.h>
 
+#define UNUSED(x)                       ((void)x)
+#define UNUSED2(x1, x2)                 (UNUSED(x1), UNUSED(x2))
+#define UNUSED3(x1, x2, x3)             (UNUSED(x1), UNUSED(x2), UNUSED(x3))
+#define UNUSED4(x1, x2, x3, x4)         (UNUSED(x1), UNUSED(x2), UNUSED(x3), UNUSED(x4))
+#define UNUSED5(x1, x2, x3, x4, x5)     (UNUSED(x1), UNUSED(x2), UNUSED(x3), UNUSED(x4), UNUSED(x5))
+
 extern volatile uint8_t exitflag; //fix for issue #136
 
 //group csv import struct
@@ -921,12 +927,12 @@ void nxdn_message_type (dsd_opts * opts, dsd_state * state, uint8_t MessageType)
 void nxdn_voice (dsd_opts * opts, dsd_state * state, int voice, uint8_t dbuf[182]);
 
 //OP25 NXDN CRC functions
-static inline int load_i(const uint8_t val[], int len);
-static uint8_t crc6(const uint8_t buf[], int len);
-static uint16_t crc12f(const uint8_t buf[], int len);
-static uint16_t crc15(const uint8_t buf[], int len);
-static uint16_t crc16cac(const uint8_t buf[], int len);
-static uint8_t crc7_scch(uint8_t bits[], int len); //converted from op25 crc6
+int load_i(const uint8_t val[], int len);
+uint8_t crc6(const uint8_t buf[], int len);
+uint16_t crc12f(const uint8_t buf[], int len);
+uint16_t crc15(const uint8_t buf[], int len);
+uint16_t crc16cac(const uint8_t buf[], int len);
+uint8_t crc7_scch(uint8_t bits[], int len); //converted from op25 crc6
 
 /* NXDN Convolution functions */
 void CNXDNConvolution_start(void);

--- a/src/dmr_block.c
+++ b/src/dmr_block.c
@@ -12,7 +12,7 @@
 void dmr_dheader (dsd_opts * opts, dsd_state * state, uint8_t dheader[], uint8_t dheader_bits[], uint32_t CRCCorrect, uint32_t IrrecoverableErrors)
 {
   
-  uint32_t i, j, k;
+  uint32_t i;
   uint8_t slot = state->currentslot;
 
   //clear out unified pdu 'superframe' slot
@@ -30,7 +30,8 @@ void dmr_dheader (dsd_opts * opts, dsd_state * state, uint8_t dheader[], uint8_t
     uint8_t dpf = (uint8_t)ConvertBitIntoBytes(&dheader_bits[4], 4); //data packet format
     uint8_t sap = (uint8_t)ConvertBitIntoBytes(&dheader_bits[8], 4); //service access point
     uint8_t poc = (uint8_t)ConvertBitIntoBytes(&dheader_bits[8], 4); //padding octets
-    
+    UNUSED(ab);
+
     uint32_t target = (uint32_t)ConvertBitIntoBytes(&dheader_bits[16], 24); //destination llid 
     uint32_t source = (uint32_t)ConvertBitIntoBytes(&dheader_bits[40], 24); //source llid
 
@@ -121,6 +122,7 @@ void dmr_dheader (dsd_opts * opts, dsd_state * state, uint8_t dheader[], uint8_t
     uint8_t p_sap  = (uint8_t)ConvertBitIntoBytes(&dheader_bits[0], 4);
     uint8_t p_mfid = (uint8_t)ConvertBitIntoBytes(&dheader_bits[8], 8);
     uint8_t p_pot  = (uint8_t)ConvertBitIntoBytes(&dheader_bits[3], 5); //looking for LRRP pot_report
+    UNUSED(p_pot);
 
     fprintf (stderr, "%s ", KGRN);
     fprintf (stderr, "\n");
@@ -379,6 +381,7 @@ void dmr_udt_cspdu_converter (dsd_opts * opts, dsd_state * state, uint8_t block_
   uint8_t udt_opcode = (uint8_t)ConvertBitIntoBytes(&block_bits[74], 6); //for observation testing
   cs_byte[1] = 0; //set mfid to zero for now (may use custom value if needed later)
   uint8_t udt_mfid = 0; //setting to zero
+  UNUSED2(udt_opcode, udt_mfid);
 
   //should be 34 total (maximum) after removing tailing CRC16 (initial and last block)
   for (i = 0; i < 34; i++) cs_byte[2+i] = block_bytes[12+i];
@@ -403,7 +406,7 @@ void dmr_udt_cspdu_converter (dsd_opts * opts, dsd_state * state, uint8_t block_
 //assemble the blocks as they come in, shuffle them into the unified dmr_pdu_sf
 void dmr_block_assembler (dsd_opts * opts, dsd_state * state, uint8_t block_bytes[], uint8_t block_len, uint8_t databurst, uint8_t type)
 {
-  int i, j, k;
+  int i, j;
   uint8_t lb = 0; //mbc last block
   uint8_t pf = 0; //mbc protect flag
 

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -13,8 +13,7 @@
 //processing voice and/or data on both BS slots (channels) simultaneously
 void dmrBS (dsd_opts * opts, dsd_state * state)
 {
-  int i, j, k, l, dibit;
-  int *dibit_p;
+  int i, dibit;
   
   char ambe_fr[4][24];
   char ambe_fr2[4][24];
@@ -37,6 +36,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
   uint8_t emb_ok = 0;
   uint8_t tact_okay = 0;
   uint8_t cach_err = 0;
+  UNUSED(cach_err);
 
   uint8_t internalslot;
   uint8_t vc1;
@@ -46,13 +46,13 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
   uint8_t cc = 25;
   uint8_t power = 9; //power and pre-emption indicator
   uint8_t lcss = 9;
+  UNUSED2(cc, lcss);
   
   //would be ideal to grab all dibits and break them into bits to pass to new data handler?
   uint8_t dummy_bits[196]; 
   memset (dummy_bits, 0, sizeof(dummy_bits));
   
   //add time to mirror printFrameSync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);
@@ -492,7 +492,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
 //Process buffered half frame and 2nd half and then jump to full BS decoding
 void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
 {
-  int i, j, k, l, dibit;
+  int i, dibit;
   int *dibit_p;
   char ambe_fr[4][24];
   char ambe_fr2[4][24];
@@ -512,6 +512,7 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
   uint8_t tact_okay = 0;
   uint8_t cach_err = 0;
   uint8_t sync_okay = 1;
+  UNUSED(cach_err);
 
   uint8_t internalslot;
 
@@ -523,7 +524,6 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
   19, 5, 20, 21, 22, 6, 23
   }; 
   //add time to mirror printFrameSync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);

--- a/src/dmr_csbk.c
+++ b/src/dmr_csbk.c
@@ -29,6 +29,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
   csbk_pf  = ( (cs_pdu[0] & 0x40) >> 6 );
   csbk_o   =    cs_pdu[0] & 0x3F; 
   csbk_fid =    cs_pdu[1]; //feature set id
+  UNUSED(csbk_lb);
 
   //check, regardless of CRC err
   if (IrrecoverableErrors == 0)
@@ -103,6 +104,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         //target and source are always the same bits
         uint32_t target = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[32], 24);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[56], 24);
+        UNUSED2(st1, st3);
 
         //move mbc variables out of if statement
         uint8_t mbc_lb = 0; //
@@ -118,6 +120,8 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint16_t mbc_abs_tx_step = 0;
         uint16_t mbc_abs_rx_int = 0;
         uint16_t mbc_abs_rx_step = 0;
+        UNUSED5(mbc_lb, mbc_pf, mbc_csbko, mbc_res, mbc_cc);
+        UNUSED4(mbc_res2, mbc_cdefparms, mbc_abs_tx_int, mbc_abs_tx_step);
 
         fprintf (stderr, "\n");
         //added my best guess as to how dsdplus arrives at a dmr channel value (seems pretty consistent) as C+
@@ -294,14 +298,14 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t nrandwait = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[31], 4);
         uint8_t regreq = cs_pdu_bits[35];
         uint8_t backoff = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[36], 4);
+        UNUSED5(reserved, tsccas, sync, offset, active);
+        UNUSED3(sf, nrandwait, backoff);
 
         uint8_t model = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[40], 2);
         uint16_t net = 0;
         uint16_t site = 0;
 
         //DMR Location Area - DMRLA
-        uint16_t sys_area = 0;
-        uint16_t sub_area = 0;
         uint16_t sub_mask = 0x1;
         //tiny n 1-3; small 1-5; large 1-8; huge 1-10
         uint16_t n = 1; //The minimum value of DMRLA is normally ≥ 1, 0 is reserved
@@ -406,6 +410,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         //fprintf (stderr, "\n  SYSCODE: %016b", syscode);
         //fprintf (stderr, "\n  SYSCODE: %02b.%b.%b", model, net, site); //won't show leading zeroes, but may not be required
         //fprintf (stderr, "\n  SYSCODE: %04X", syscode);
+        UNUSED(syscode);
       } 
 
       //P_CLEAR
@@ -427,6 +432,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t gi = cs_pdu_bits[31];
         uint32_t target = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[32], 24);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[56], 24);
+        UNUSED(reserved);
 
         if (gi)  fprintf (stderr, " Group");
         if (!gi) fprintf (stderr, " Private");
@@ -462,16 +468,17 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t model = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[40], 2);
         uint16_t net = 0;
         uint16_t site = 0;
+        UNUSED2(net, site);
 
         //DMR Location Area - DMRLA
-        uint16_t sys_area = 0;
-        uint16_t sub_area = 0;
         uint16_t sub_mask = 0x1;
         //tiny n 1-3; small 1-5; large 1-8; huge 1-10
         uint16_t n = 1; //The minimum value of DMRLA is normally ≥ 1, 0 is reserved
+        UNUSED(sub_mask);
 
         //channel number from Broadcast Parms 2
         uint16_t lpchannum = 0;
+        UNUSED(lpchannum);
 
         char model_str[8];
         char par_str[8]; //category A, B, AB, or reserved
@@ -561,7 +568,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint16_t syscode = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[40], 16);
         //fprintf (stderr, "\n  SYSCODE: %016b", syscode);
         //fprintf (stderr, "\n  SYSCODE: %04X", syscode);
-
+        UNUSED(syscode);
       }
 
       if (csbk_o == 28) 
@@ -651,6 +658,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t blocks = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[24], 8);
         uint32_t target = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[32], 24);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&cs_pdu_bits[56], 24);
+        UNUSED2(res, blocks);
 
         uint8_t target_hash[24]; 
         uint8_t tg_hash = 0; 
@@ -1453,6 +1461,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
         uint8_t xpt_site_rp[4];
         uint8_t xpt_site_u1[4];
         uint8_t xpt_site_u2[4];
+        UNUSED2(xpt_site_u1, xpt_site_u2);
 
         uint8_t xpt_sn = (uint8_t)ConvertBitIntoBytes(&cs_pdu_bits[0], 2); 
 

--- a/src/dmr_data.c
+++ b/src/dmr_data.c
@@ -26,13 +26,14 @@ dmr_data_sync (dsd_opts * opts, dsd_state * state)
   char sync[25];
   char syncdata[48];
   char cachdata[25];
+  UNUSED(syncdata);
 
-  char bursttype[5];
   uint8_t burst;
   char info[196];
   unsigned char SlotType[20]; 
   unsigned int SlotTypeOk;
   uint8_t cach_err = 0;
+  UNUSED(cach_err);
 
   int cachInterleave[24] = 
   {0, 7, 8, 9, 1, 10,

--- a/src/dmr_dburst.c
+++ b/src/dmr_dburst.c
@@ -26,13 +26,13 @@ void dmr_data_burst_handler(dsd_opts * opts, dsd_state * state, uint8_t info[196
   uint32_t CRCCorrect       = 0;
   uint32_t IrrecoverableErrors = 0;
   uint8_t slot = state->currentslot;
-  uint8_t block = state->data_block_counter[slot];
 
   //confirmed data 
   uint8_t dbsn = 0; //data block serial number for confirmed data blocks
   uint8_t blockcounter = 0; //local block count
   uint8_t confdatabits[250]; //array to reshuffle conf data block bits into sequence for crc9 check
   memset (confdatabits, 0, sizeof(confdatabits));
+  UNUSED(dbsn);
 
   //BPTC 196x96 Specific
   uint8_t  BPTCDeInteleavedData[196];

--- a/src/dmr_flco.c
+++ b/src/dmr_flco.c
@@ -30,6 +30,7 @@ void dmr_flco (dsd_opts * opts, dsd_state * state, uint8_t lc_bits[], uint32_t C
   int is_cap_plus = 0;
   int is_alias = 0;
   int is_gps = 0;
+  UNUSED(capsite);
 
   //XPT 'Things'
   int is_xpt = 0;
@@ -41,6 +42,7 @@ void dmr_flco (dsd_opts * opts, dsd_state * state, uint8_t lc_bits[], uint32_t C
   uint8_t xpt_res_c = 0; //unknown values of other bits of the XPT LC
   uint8_t target_hash[24]; //for XPT (and others if desired, get the hash and compare against SLC or XPT Status CSBKs)
   uint8_t tg_hash = 0; //value of the hashed TG
+  UNUSED3(xpt_res_a, xpt_res_b, xpt_res_c);
 
   uint8_t slot = state->currentslot;
   uint8_t unk = 0; //flag for unknown FLCO + FID combo
@@ -590,7 +592,7 @@ uint8_t dmr_cach (dsd_opts * opts, dsd_state * state, uint8_t cach_bits[25])
   int i, j;
   uint8_t err = 0;
   uint8_t tact_valid = 0; 
-  uint8_t cach_valid = 0;
+  UNUSED(tact_valid);
 
   bool h1, h2, h3, crc; 
 
@@ -603,6 +605,7 @@ uint8_t dmr_cach (dsd_opts * opts, dsd_state * state, uint8_t cach_bits[25])
   uint8_t at = 0; //access type, set to 1 during continuous transmission mode 
   uint8_t slot = 2; //tdma time slot
   uint8_t lcss = 0; //link control start stop (9.3.3) NOTE: There is no Single fragment LC defined for CACH signalling
+  UNUSED2(at, slot);
 
   //cach_bits are already de-interleaved upon initial collection (still needs secodary slco de-interleave)
   for (i = 0; i < 7; i++)
@@ -764,6 +767,8 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
   uint16_t netsite = (uint16_t)ConvertBitIntoBytes(&slco_bits[6], 12);
   uint8_t reg = slco_bits[18]; //registration required/not required or normalchanneltype/composite cch
   uint8_t csc = (uint16_t)ConvertBitIntoBytes(&slco_bits[19], 9); //common slot counter, 0-511
+  UNUSED(netsite);
+
   uint16_t net = 0;
 	uint16_t site = 0;
   char model_str[8];
@@ -775,8 +780,6 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
   uint8_t ts2_hash = (uint8_t)ConvertBitIntoBytes(&slco_bits[20], 8); //ts2 address hash (crc8) //361-1 B.3.7
 
   //DMR Location Area - DMRLA - should probably be state variables so we can use this in both slc and csbk
-  uint16_t sys_area = 0;
-  uint16_t sub_area = 0;
   uint16_t sub_mask = 0x1;
   //tiny n 1-3; small 1-5; large 1-8; huge 1-10
   uint16_t n = 1; //The minimum value of DMRLA is normally ≥ 1, 0 is reserved
@@ -871,7 +874,7 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
     uint16_t syscode = (uint16_t)ConvertBitIntoBytes(&slco_bits[4], 14);
     //fprintf (stderr, "\n  SYSCODE: %014b", syscode);
     //fprintf (stderr, "\n  SYSCODE: %02b.%b.%b", model, net, site); //won't show leading zeroes, but may not be required
-
+    UNUSED(syscode);
   }
   else if (slco == 0x3) //P_SYS_Parms
   {
@@ -886,7 +889,7 @@ void dmr_slco (dsd_opts * opts, dsd_state * state, uint8_t slco_bits[])
     uint16_t syscode = (uint16_t)ConvertBitIntoBytes(&slco_bits[4], 14);
     //fprintf (stderr, "\n  SYSCODE: %014b", syscode);
     //fprintf (stderr, "\n  SYSCODE: %02b.%b.%b", model, net, site); //won't show leading zeroes, but may not be required
-
+    UNUSED(syscode);
   }
   else if (slco == 0x0) //null
     fprintf (stderr, " SLCO NULL ");
@@ -954,8 +957,6 @@ void dmr_embedded_alias_header (dsd_opts * opts, dsd_state * state, uint8_t lc_b
 {
   
   uint8_t slot = state->currentslot;
-  uint8_t pf; 
-  uint8_t res;
   uint8_t format = (uint8_t)ConvertBitIntoBytes(&lc_bits[16], 2); 
   uint8_t len;
 
@@ -982,6 +983,7 @@ void dmr_embedded_alias_blocks (dsd_opts * opts, dsd_state * state, uint8_t lc_b
   uint8_t format = state->dmr_alias_format[slot]; //0=7-bit; 1=ISO8; 2=UTF-8; 3=UTF16BE
   uint8_t len =  state->dmr_alias_len[slot];
   uint8_t start; //starting position depends on context of block and format
+  UNUSED(format);
 
   //Cap Max Variation
   uint8_t fid = (uint8_t)ConvertBitIntoBytes(&lc_bits[8], 8);
@@ -1049,6 +1051,7 @@ void dmr_embedded_gps (dsd_opts * opts, dsd_state * state, uint8_t lc_bits[])
   uint8_t res_a = lc_bits[1];
   uint8_t res_b = (uint8_t)ConvertBitIntoBytes(&lc_bits[16], 4);
   uint8_t pos_err = (uint8_t)ConvertBitIntoBytes(&lc_bits[20], 3);
+  UNUSED2(res_a, res_b);
   
   uint32_t lon_sign = lc_bits[23]; 
   uint32_t lon = (uint32_t)ConvertBitIntoBytes(&lc_bits[24], 24); 

--- a/src/dmr_le.c
+++ b/src/dmr_le.c
@@ -189,6 +189,7 @@ void dmr_sbrc (dsd_opts * opts, dsd_state * state, uint8_t power)
   uint8_t crc7_okay = 0; //RC
   uint8_t crc3_okay = 0; //TXI
   uint8_t txi = 0; //SEE: https://patents.google.com/patent/US8271009B2
+  UNUSED(txi);
   
   //NOTE: Any previous mentions to Cap+ in this area may have been in error,
   //The signalling observed here was actually TXI information, not Cap+ Specifically

--- a/src/dmr_ms.c
+++ b/src/dmr_ms.c
@@ -13,8 +13,7 @@
 void dmrMS (dsd_opts * opts, dsd_state * state)
 {
 
-  int i, j, k, l, dibit;
-  int *dibit_p;
+  int i, j, dibit;
   char ambe_fr[4][24];
   char ambe_fr2[4][24];
   char ambe_fr3[4][24];
@@ -32,20 +31,13 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
 
   //cach
   char cachdata[25]; 
-  int cachInterleave[24] =
-  {0, 7, 8, 9, 1, 10,
-   11, 12, 2, 13, 14,
-   15, 3, 16, 4, 17, 18,
-   19, 5, 20, 21, 22, 6, 23
-  }; 
 
   //cach tact bits
   uint8_t tact_bits[7];
 
-  uint8_t emb_ok = 0;
   uint8_t tact_okay = 0;
-  uint8_t cach_err = 0;
   uint8_t EmbeddedSignallingOk = 0;
+  UNUSED(EmbeddedSignallingOk);
 
   uint8_t internalslot;
   uint8_t vc;
@@ -54,13 +46,13 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
   uint8_t cc = 25;
   uint8_t power = 9; //power and pre-emption indicator
   uint8_t lcss = 9;
+  UNUSED2(cc, lcss);
 
   //dummy bits to pass to dburst for link control
   uint8_t dummy_bits[196];
   memset (dummy_bits, 0, sizeof (dummy_bits));
 
   //add time to mirror printFrameSync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);
@@ -77,8 +69,6 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
   }
 
   vc = 2;
-
-  short int skipcount = 0;
 
   //Hardset variables for MS/Mono
   state->currentslot = 0; //0
@@ -368,7 +358,7 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
 //collect buffered 1st half and get 2nd half voice payload and then jump to full MS Voice decoding.
 void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
 {
-  int i, j, k, l, dibit;
+  int i, dibit;
   int *dibit_p;
 
   char ambe_fr[4][24];
@@ -386,30 +376,12 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
   char m3[4][24];
 
   const int *w, *x, *y, *z;
-  char sync[25];
-  char syncdata[48];
 
   //cach
   char cachdata[25]; 
-  int cachInterleave[24] =
-  {0, 7, 8, 9, 1, 10,
-   11, 12, 2, 13, 14,
-   15, 3, 16, 4, 17, 18,
-   19, 5, 20, 21, 22, 6, 23
-  };
-
-  int mutecurrentslot;
-  int msMode;
-  char cc[4];
-  char EmbeddedSignalling[16];
-
-  uint8_t emb_ok = 0;
-  uint8_t tact_okay = 0;
-  uint8_t cach_err = 0;
-  uint8_t EmbeddedSignallingOk = 0;
+  UNUSED(cachdata);
 
   //add time to mirror sync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);
@@ -609,12 +581,11 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
 //simplied to a simple data collector, and then passed on to dmr_data_sync for the usual processing
 void dmrMSData (dsd_opts * opts, dsd_state * state)
 {
-  int i, b, c;
+  int i;
   int dibit;
   int *dibit_p;
 
   //add time to mirror sync
-  time_t now;
   char * getTime(void) //get pretty hh:mm:ss timestamp
   {
     time_t t = time(NULL);

--- a/src/dmr_pdu.c
+++ b/src/dmr_pdu.c
@@ -38,11 +38,7 @@ char * getDateL(void) {
 void dmr_pdu (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR_PDU[])
 {
 
-  uint8_t message_len = 0;
   uint8_t slot = state->currentslot;
-  uint8_t blocks  = state->data_header_blocks[slot]; 
-  uint8_t padding = state->data_header_padding[slot];
-  uint8_t lrrp_conf = 0;
 
   //check for more available flag info, etc on these prior to running
   if (DMR_PDU[0] == 0x01) dmr_locn (opts, state, block_len, DMR_PDU);
@@ -59,7 +55,7 @@ void dmr_pdu (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR
 //this is by no means an extensive LRRP list and is prone to error (unless somebody has the manual or something)
 void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR_PDU[])
 {
-  int i, j;
+  int i;
   uint16_t message_len = 0;
   uint8_t slot = state->currentslot;
   uint8_t blocks = state->data_header_blocks[slot];
@@ -96,6 +92,7 @@ void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
   uint16_t vel = 0;
   double velocity = 0;
   uint8_t vel_set = 0;
+  UNUSED(vel);
 
   //track, direction, degrees
   uint8_t degrees = 0;
@@ -417,7 +414,7 @@ void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
 
 void dmr_locn (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DMR_PDU[])
 {
-  int i, j;
+  int i;
   uint8_t slot = state->currentslot;
   uint8_t blocks = state->data_header_blocks[slot];
   uint8_t padding = state->data_header_padding[slot];
@@ -467,8 +464,7 @@ void dmr_locn (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
   //N is positive, E is positive?? Assuming its like a 2D plane
   int lat_sign = 1; //positive 1 or negative 1
   int lon_sign = 1; //positive 1 or negative 1
-  double lat_fin = 0;
-  double lon_fin = 0;
+  UNUSED2(lat_sign, lon_sign);
 
   //start looking for specific bytes corresponding to 'letters' A (time), NSEW (ordinal directions), etc
   for (i = 0; i < ( (blocks*block_len) - (padding+4) ); i++)

--- a/src/dpmr_voice.c
+++ b/src/dpmr_voice.c
@@ -53,15 +53,10 @@ void processdPMRvoice (dsd_opts * opts, dsd_state * state)
   uint32_t CCH_EmergencyPriority[NB_OF_DPMR_VOICE_FRAME_TO_DECODE];
   uint32_t CCH_Reserved[NB_OF_DPMR_VOICE_FRAME_TO_DECODE];
   uint32_t CCH_SlowData[NB_OF_DPMR_VOICE_FRAME_TO_DECODE];
-  uint32_t *errs;
-  uint32_t *errs2;
-  uint8_t AmbeBitDescrambled[49] = {0};
-  uint32_t ScramblerKey = 0;
   uint32_t PartOfSuperFrame = 0;
-  uint32_t VoiceFrameFlag = 1; /* We consider the current frame as a voice frame */
-  uint32_t AttachedDataFlag = 0;
   uint8_t CalledID[8] = {0};
   uint8_t CallingID[8] = {0};
+  UNUSED(PartOfSuperFrame);
 
   /* First CCH (Control CHannel) - 72 bit */
   k = 0;

--- a/src/dsd_audio.c
+++ b/src/dsd_audio.c
@@ -423,10 +423,7 @@ void writeSynthesizedVoiceR (dsd_opts * opts, dsd_state * state)
 
 void writeRawSample (dsd_opts * opts, dsd_state * state, short sample)
 {
-  int n;
-  short aout_buf[160];
-  short *aout_buf_p;
-
+  //short aout_buf[160];
   //sf_write_short(opts->wav_out_raw, aout_buf, 160);
 
   //only write if actual audio, truncate silence
@@ -441,6 +438,7 @@ void
 playSynthesizedVoice (dsd_opts * opts, dsd_state * state)
 {
   ssize_t result;
+  UNUSED(result);
 
   if (state->audio_out_idx > opts->delay)
   {
@@ -475,6 +473,7 @@ void
 playSynthesizedVoiceR (dsd_opts * opts, dsd_state * state)
 {
   ssize_t result;
+  UNUSED(result);
 
   if (state->audio_out_idxR > opts->delay)
   {
@@ -521,7 +520,7 @@ openAudioOutDevice (dsd_opts * opts, int speed)
   }
 	else
 	{
-		struct stat stat_buf;
+  // struct stat stat_buf;
   // if(stat(opts->audio_out_dev, &stat_buf) != 0 && strncmp(opts->audio_out_dev, "pulse", 5 != 0)) //HERE
   //   {
   //     fprintf (stderr,"Error, couldn't open %s\n", opts->audio_out_dev);

--- a/src/dsd_dibit.c
+++ b/src/dsd_dibit.c
@@ -483,6 +483,7 @@ skipDibit (dsd_opts * opts, dsd_state * state, int count)
 
   short sample;
   int i;
+  UNUSED(sample);
 
   for (i = 0; i < (count); i++)
     {

--- a/src/dsd_file.c
+++ b/src/dsd_file.c
@@ -127,6 +127,7 @@ void PrintIMBEData (dsd_opts * opts, dsd_state * state, char *imbe_d) //for P25P
   int i, j, k;
   unsigned char b;
   unsigned char err;
+  UNUSED(err);
 
   err = (unsigned char) state->errs2;
   k = 0;
@@ -162,6 +163,7 @@ void PrintAMBEData (dsd_opts * opts, dsd_state * state, char *ambe_d)
   int i, j, k;
   unsigned char b;
   unsigned char err;
+  UNUSED(err);
 
   err = (unsigned char) state->errs2;
   k = 0;

--- a/src/dsd_frame.c
+++ b/src/dsd_frame.c
@@ -31,7 +31,7 @@ printFrameInfo (dsd_opts * opts, dsd_state * state)
   level = (int) state->max / 164;
   if (opts->verbose > 0)
     {
-      //fprintf (stderr,"inlvl: %2i%% ", level);
+      fprintf (stderr,"inlvl: %2i%% ", level);
     }
   if (state->nac != 0)
     {
@@ -59,8 +59,10 @@ processFrame (dsd_opts * opts, dsd_state * state)
   char duid[3];
   char nac[13];
   int level;
+  UNUSED2(nac, level);
 
   char status_0;
+  UNUSED(status_0);
   char bch_code[63];
   int index_bch_code;
   unsigned char parity;

--- a/src/dsd_frame_sync.c
+++ b/src/dsd_frame_sync.c
@@ -205,7 +205,7 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
     state->last_cc_sync_time = time(NULL); //set again to give another x seconds
   }
 
-  int i, j, t, o, dibit, sync, symbol, synctest_pos, lastt;
+  int i, t, dibit, sync, symbol, synctest_pos, lastt;
   char synctest[25];
   char synctest12[13]; //dPMR
   char synctest10[11]; //NXDN FSW only
@@ -217,10 +217,9 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
   char synctest48[49]; //EDACS
   char modulation[8];
   char *synctest_p;
-  int symboltest_pos; //symbol test position, match to synctest_pos
-  int symboltest_p[10240]; //make this an array instead
   char synctest_buf[10240]; //what actually is assigned to this, can't find its use anywhere?
   int lmin, lmax, lidx;
+  UNUSED2(synctest18, synctest21);
   
   //assign t_max value based on decoding type expected (all non-auto decodes first)
   int t_max; //maximum values allowed for t will depend on decoding type - NXDN will be 10, others will be more
@@ -246,7 +245,6 @@ getFrameSync (dsd_opts * opts, dsd_state * state)
 
   int lbuf[t_max], lbuf2[t_max];
   int lsum;
-  char spectrum[64];
   //init the lbuf
   memset (lbuf, 0, sizeof(lbuf));
   memset (lbuf2, 0, sizeof(lbuf2));

--- a/src/dsd_import.c
+++ b/src/dsd_import.c
@@ -18,6 +18,7 @@ int csvGroupImport(dsd_opts * opts, dsd_state * state)
   int row_count = 0;
   int field_count = 0;
   long int group_number = 0; //local group number for array index value
+  UNUSED(group_number);
   int i = 0;
   while (fgets(buffer, BSIZE, fp)) {
     field_count = 0;

--- a/src/dsd_mbe.c
+++ b/src/dsd_mbe.c
@@ -139,7 +139,7 @@ void playMbeFiles (dsd_opts * opts, dsd_state * state, int argc, char **argv)
       else if (state->mbe_file_type > 0) //ambe files
       {
         readAmbe2450Data (opts, state, ambe_d);
-        int j, x;
+        int x;
         unsigned long long int k;
         if (state->K != 0) //apply Pr key
         {
@@ -185,7 +185,6 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
   int i;
   char imbe_d[88];
   char ambe_d[49];
-  char ambe_d_str[50];
   unsigned long long int k;
   int x;
 

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -208,7 +208,6 @@ void beeper (dsd_opts * opts, dsd_state * state, int type)
     beep = fopen (wav_name, "ro");
     uint8_t buf[1024];
     memset (buf, 0, sizeof(buf));
-    short blip = 0;
     int loop = 1;
     while (loop == 1)
     {
@@ -494,13 +493,10 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
   WINDOW *entry_win;
   WINDOW *info_win;
 	int highlight  = 1;
-  int highlightb = 1;
   int highlightc = 1;
 	int choice  = 0;
-  int choiceb = 0;
   int choicec = 0;
 	int c;
-  int d;
   int e;
 
   startx = 2;

--- a/src/dsd_reset.c
+++ b/src/dsd_reset.c
@@ -6,7 +6,7 @@
 void resetState (dsd_state * state)
 {
 
-  int i, j;
+  int i;
 
   //Dibit Buffer -- Free Allocated Memory
   // free (state->dibit_buf);

--- a/src/dsd_rigctl.c
+++ b/src/dsd_rigctl.c
@@ -35,7 +35,7 @@ void error(char *msg) {
 //
 int Connect (char *hostname, int portno)
 {
-    int sockfd, n;
+    int sockfd;
     struct sockaddr_in serveraddr;
     struct hostent *server;
 
@@ -222,9 +222,8 @@ bool GetSignalLevelEx(int sockfd, double *dBFS, int n_samp)
 //shoe in UDP input connection here...still having issues that I don't know how to resolve
 int UDPBind (char *hostname, int portno)
 {
-    int sockfd, n;
-    struct sockaddr_in serveraddr, client_addr;
-    struct hostent *server;
+    int sockfd;
+    struct sockaddr_in serveraddr;
 
     /* socket: create the socket */
     //UDP socket

--- a/src/dsd_serial.c
+++ b/src/dsd_serial.c
@@ -73,6 +73,7 @@ resumeScan (dsd_opts * opts, dsd_state * state)
 
   char cmd[16];
   ssize_t result;
+  UNUSED(result);
 
   if (opts->serial_fd > 0)
     {

--- a/src/dsd_symbol.c
+++ b/src/dsd_symbol.c
@@ -20,7 +20,7 @@
 int
 getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
 {
-  short sample, sample2;
+  short sample;
   int i, sum, symbol, count;
   ssize_t result;
 
@@ -512,9 +512,9 @@ getSymbol (dsd_opts * opts, dsd_state * state, int have_sync)
     state->symbolc = fgetc(opts->symbolfile);
 
     //experimental throttle
-    useconds_t stime = state->symbol_throttle;
     if (state->use_throttle == 1)
     {
+      // useconds_t stime = state->symbol_throttle;
       // usleep(stime);
       usleep(.003); //very environment specific, tuning to cygwin
     }

--- a/src/dstar.c
+++ b/src/dstar.c
@@ -29,10 +29,8 @@
 
 void processDSTAR(dsd_opts * opts, dsd_state * state) {
 	// extracts AMBE frames from D-STAR voice frame
-	int i, j, dibit;
+	int i, dibit;
 	char ambe_fr[4][24];
-	unsigned char data[9];
-	unsigned int bits[4];
 	int framecount;
 	int sync_missed = 0;
 	unsigned char slowdata[4];
@@ -165,7 +163,7 @@ void processDSTAR(dsd_opts * opts, dsd_state * state) {
 
 void processDSTAR_HD(dsd_opts * opts, dsd_state * state) {
 
-	int i, j;
+	int j;
 	int radioheaderbuffer[660];
 
 	for (j = 0; j < 660; j++) {

--- a/src/dstar_header.c
+++ b/src/dstar_header.c
@@ -26,9 +26,8 @@ void dstar_header_decode(dsd_state * state, int radioheaderbuffer[660]) {
 	unsigned char radioheader[41];
 	int octetcount, bitcount, loop;
 	unsigned char bit2octet[] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
-	unsigned int FCSinheader;
-	unsigned int FCScalculated;
 	int len;
+	UNUSED(len);
 
 	scramble(radioheaderbuffer, radioheaderbuffer2);
 	deinterleave(radioheaderbuffer2, radioheaderbuffer);

--- a/src/edacs-bch3.c
+++ b/src/edacs-bch3.c
@@ -332,7 +332,8 @@ decode_bch()
 {
 	register int    i, j, u, q, t2, count = 0, syn_error = 0;
 	int             elp[1026][1024], d[1026], l[1026], u_lu[1026], s[1025];
-	int             root[200], loc[200], err[1024], reg[201];
+	int             root[200], loc[200], reg[201];
+	(void)(root);
 
 	t2 = 2 * t;
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -64,7 +64,6 @@ void edacs(dsd_opts * opts, dsd_state * state)
   unsigned char command = 0xFF;
   unsigned char mt1 = 0x1F;
   unsigned char mt2 = 0xF;
-  unsigned char mta = 0;
   unsigned char lcn = 0;
 
   //commands; may not use these anymore
@@ -72,10 +71,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
   unsigned int idcmd = 0xFD;
   unsigned int peercmd = 0xF88; //using for EA detection test
   unsigned int netcmd = 0xF3; //using for Networked Test
+  UNUSED2(vcmd, idcmd);
 
   state->edacs_vc_lcn = -1; //init on negative for ncurses and tuning
 
-  int i, j;
+  int i;
   int edacs_bit[241] = {0}; //zero out bit array and collect bits into it.
 
   for (i = 0; i < 240; i++) //288 bits every transmission minus 48 bit (24 dibit) sync pattern
@@ -381,6 +381,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int a = afs >> 7; 
         int fs = afs & 0x7F;
         int status  = (fr_1t & 0xF00000000) >> 32;
+        UNUSED(status);
         if (afs > 0) state->lastsrc = afs; 
         fprintf (stderr, "%s", KGRN);
         fprintf (stderr, " AFS [0x%03X] [%02d-%03d] LCN [%02d]", afs, a, fs, lcn);

--- a/src/nxdn_convolution.c
+++ b/src/nxdn_convolution.c
@@ -45,7 +45,7 @@ static const uint8_t CNXDNConvolution_BRANCH_TABLE1[] = {0U, 0U, 0U, 0U, 2U, 2U,
 static const uint8_t CNXDNConvolution_BRANCH_TABLE2[] = {0U, 2U, 2U, 0U, 0U, 2U, 2U, 0U};
 
 static const unsigned int CNXDNConvolution_NUM_OF_STATES_D2 = 8U;
-static const unsigned int CNXDNConvolution_NUM_OF_STATES = 16U;
+//static const unsigned int CNXDNConvolution_NUM_OF_STATES = 16U;
 static const uint32_t     CNXDNConvolution_M = 4U;
 static const unsigned int CNXDNConvolution_K = 5U;
 

--- a/src/nxdn_deperm.c
+++ b/src/nxdn_deperm.c
@@ -33,11 +33,11 @@ static const uint8_t scramble_t[] = { //values are the position values we need t
 	168, 170, 171, 174, 175, 176, 177, 181
 };
 
-static const int PARITY[] = {
-  0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 
-  1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 
-  1, 0, 0, 1, 1, 0, 1, 0, 0, 1
-};
+// static const int PARITY[] = {
+//   0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 
+//   1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 
+//   1, 0, 0, 1, 1, 0, 1, 0, 0, 1
+// };
 
 //decoding functions here
 void nxdn_descramble(uint8_t dibits[], int len)
@@ -976,7 +976,7 @@ void LFSRN(char * BufferIn, char * BufferOut, dsd_state * state)
   state->payload_miN = lfsr & 0x7FFF;
 }
 
-static inline int load_i(const uint8_t val[], int len) {
+int load_i(const uint8_t val[], int len) {
 	int acc = 0;
 	for (int i=0; i<len; i++){
 		acc = (acc << 1) + (val[i] & 1);
@@ -984,7 +984,7 @@ static inline int load_i(const uint8_t val[], int len) {
 	return acc;
 }
 
-static uint8_t crc6(const uint8_t buf[], int len)
+uint8_t crc6(const uint8_t buf[], int len)
 {
 	uint8_t s[6];
 	uint8_t a;
@@ -1002,7 +1002,7 @@ static uint8_t crc6(const uint8_t buf[], int len)
 	return load_i(s, 6);
 }
 
-static uint16_t crc12f(const uint8_t buf[], int len)
+uint16_t crc12f(const uint8_t buf[], int len)
 {
 	uint8_t s[12];
 	uint8_t a;
@@ -1026,7 +1026,7 @@ static uint16_t crc12f(const uint8_t buf[], int len)
 	return load_i(s, 12);
 }
 
-static uint16_t crc15(const uint8_t buf[], int len)
+uint16_t crc15(const uint8_t buf[], int len)
 {
 	uint8_t s[15];
 	uint8_t a;
@@ -1053,7 +1053,7 @@ static uint16_t crc15(const uint8_t buf[], int len)
 	return load_i(s, 15);
 }
 
-static uint16_t crc16cac(const uint8_t buf[], int len)
+uint16_t crc16cac(const uint8_t buf[], int len)
 {
 	uint32_t crc = 0xc3ee; //not sure why this though
 	uint32_t poly = (1<<12) + (1<<5) + 1; //poly is fine
@@ -1066,7 +1066,7 @@ static uint16_t crc16cac(const uint8_t buf[], int len)
 	return crc & 0xffff;
 }
 
-static uint8_t crc7_scch(uint8_t bits[], int len)
+uint8_t crc7_scch(uint8_t bits[], int len)
 {
 	uint8_t s[7];
 	uint8_t a;

--- a/src/nxdn_element.c
+++ b/src/nxdn_element.c
@@ -62,10 +62,7 @@ void NXDN_SACCH_Full_decode(dsd_opts * opts, dsd_state * state)
 void NXDN_Elements_Content_decode(dsd_opts * opts, dsd_state * state,
                                   uint8_t CrcCorrect, uint8_t * ElementsContent)
 {
-  uint32_t i;
   uint8_t MessageType;
-  uint64_t CurrentIV = 0;
-  unsigned long long int FullMessage = 0;
   /* Get the "Message Type" field */
   MessageType  = (ElementsContent[2] & 1) << 5;
   MessageType |= (ElementsContent[3] & 1) << 4;
@@ -332,6 +329,7 @@ void nxdn_ca_info_handler (dsd_state * state, uint32_t ca_info)
   uint32_t step = (ca_info >> 21) & 0x3; //Stepping
   uint32_t base = (ca_info >> 18) & 0x7; //Base Frequency
   uint32_t spare = ca_info & 0x3FF;
+  UNUSED(spare);
 
   //set state variable here to tell us to use DFA or Channel Versions
   if (RCN == 1)
@@ -355,7 +353,7 @@ void NXDN_decode_VCALL_ASSGN(dsd_opts * opts, dsd_state * state, uint8_t * Messa
   uint16_t DestinationID = 0;
   uint8_t  CallTimer = 0;
   uint16_t Channel = 0;
-  uint8_t  LocationIDOption = 0;
+  UNUSED(CallTimer);
 
   uint8_t  DuplexMode[32] = {0};
   uint8_t  TransmissionMode[32] = {0};
@@ -378,6 +376,7 @@ void NXDN_decode_VCALL_ASSGN(dsd_opts * opts, dsd_state * state, uint8_t * Messa
   uint8_t  bw = 0;
   uint16_t OFN = 0;
   uint16_t IFN = 0;
+  UNUSED2(bw, IFN);
 
   /* Decode "CC Option" */
   CCOption = (uint8_t)ConvertBitIntoBytes(&Message[8], 8);
@@ -701,6 +700,7 @@ void NXDN_decode_cch_info(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint16_t channel2 = 0;
   long int freq1 = 0;
   long int freq2 = 0;
+  UNUSED2(channel2sts, freq2);
   
   //DFA
   uint8_t  bw1 = 0;
@@ -709,6 +709,7 @@ void NXDN_decode_cch_info(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint8_t  bw2 = 0;
   uint16_t OFN2 = 0;
   uint16_t IFN2 = 0;
+  UNUSED(bw2);
 
   location_id = (uint32_t)ConvertBitIntoBytes(&Message[8], 24);
   channel1sts = (uint8_t)ConvertBitIntoBytes(&Message[32], 6);
@@ -850,6 +851,7 @@ void NXDN_decode_site_info(dsd_opts * opts, dsd_state * state, uint8_t * Message
   uint16_t channel2 = 0;
   long int freq1 = 0;
   long int freq2 = 0;
+  UNUSED2(freq1, freq2);
 
   location_id = (uint32_t)ConvertBitIntoBytes(&Message[8], 24);
   cs_info     = (uint16_t)ConvertBitIntoBytes(&Message[32], 16);
@@ -908,21 +910,17 @@ void NXDN_decode_adj_site(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint32_t adj1_site = 0; 
   uint32_t adj2_site = 0;
   uint32_t adj3_site = 0;
-  uint32_t adj4_site = 0;
   //options -- 6.5.38. Adjacent Site Option -- 4 LSB are Site Number, 2 MSB are spares
   uint8_t  adj1_opt = 0;
   uint8_t  adj2_opt = 0;
   uint8_t  adj3_opt = 0;
-  uint8_t  adj4_opt = 0;
-  //channel or OFN
+ //channel or OFN
   uint16_t adj1_chan = 0;
   uint16_t adj2_chan = 0;
   uint16_t adj3_chan = 0;
-  uint16_t adj4_chan = 0;
   //DFA only BW value
   uint8_t adj1_bw = 0;
   uint8_t adj2_bw = 0;
-  uint8_t adj3_bw = 0;
 
   fprintf (stderr, "%s", KYEL);
 
@@ -1044,7 +1042,6 @@ void NXDN_decode_VCALL(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint8_t  KeyID = 0;
   uint8_t  DuplexMode[32] = {0};
   uint8_t  TransmissionMode[32] = {0};
-  unsigned long long int FullMessage = 0;
 
   uint8_t MessageType;
   /* Get the "Message Type" field */
@@ -1085,6 +1082,7 @@ void NXDN_decode_VCALL(dsd_opts * opts, dsd_state * state, uint8_t * Message)
   uint8_t idas = 0;
   uint8_t rep1 = 0;
   uint8_t rep2 = 0;
+  UNUSED(rep2);
   if (strcmp (state->nxdn_location_category, "Type-D") == 0) idas = 1;
   if (idas)
   {
@@ -1192,7 +1190,6 @@ void NXDN_decode_VCALL(dsd_opts * opts, dsd_state * state, uint8_t * Message)
 
 void NXDN_decode_VCALL_IV(dsd_opts * opts, dsd_state * state, uint8_t * Message)
 {
-  uint32_t i;
   state->payload_miN = 0; //zero out
   unsigned long long int IV = 0; 
 

--- a/src/nxdn_frame.c
+++ b/src/nxdn_frame.c
@@ -32,7 +32,6 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
   // length is implicitly 192, with frame sync in first 10 dibits
 	uint8_t dbuf[182]; 
 	uint8_t lich;
-	int answer_len = 0;
 	uint8_t answer[32];
 	uint8_t sacch_answer[32];
 	int lich_parity_received;
@@ -43,8 +42,6 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
 	int udch = 0;
 	int sacch = 0;
 	int cac = 0;
-	int sr_structure;
-	int sr_ran;
 
 	//new, and even more confusing NXDN Type-D / "IDAS" acronyms
 	int idas = 0;
@@ -57,6 +54,7 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
 	uint8_t lich_fc = 0; //Functional Channel Type
 	uint8_t lich_op = 0; //Options
 	uint8_t direction; //inbound or outbound direction
+	UNUSED2(lich_fc, lich_op);
 
 	uint8_t lich_dibits[8]; 
 	uint8_t sacch_bits[60];

--- a/src/nxdn_voice.c
+++ b/src/nxdn_voice.c
@@ -55,11 +55,10 @@ const int nZ[36] = { 5, 3, 4, 2, 3, 1,
 
 void nxdn_voice (dsd_opts * opts, dsd_state * state, int voice, uint8_t dbuf[182])
 {
-  int i, j, dibit;
+  int i;
   int start, stop;
   char ambe_fr[4][24];
 
-  unsigned char *pr;
   const int *w, *x, *y, *z;
 
   //these conditions will determine our starting and stopping value for voice

--- a/src/p25_lcw.c
+++ b/src/p25_lcw.c
@@ -17,6 +17,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
   uint8_t lc_svcopt = (uint8_t)ConvertBitIntoBytes(&LCW_bits[16], 8); //service options
   uint8_t lc_pf = LCW_bits[0]; //protect flag
   uint8_t lc_sf = LCW_bits[1]; //Implicit / Explicit MFID Format
+  UNUSED2(lc_opcode, lc_sf);
 
   if (lc_pf == 1) //check the protect flag -- if set, its an encrypted lcw
   {
@@ -60,6 +61,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
         uint16_t group = (uint16_t)ConvertBitIntoBytes(&LCW_bits[32], 16);
         uint32_t source = (uint32_t)ConvertBitIntoBytes(&LCW_bits[48], 24);
         fprintf (stderr, " - Group %d Source %d", group, source);
+        UNUSED2(res, explicit);
 
         //don't set this when zero, annoying blink occurs in ncurses
         if (group != 0) state->lasttg = group;
@@ -121,6 +123,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
         uint16_t channelt = (uint16_t)ConvertBitIntoBytes(&LCW_bits[40], 16);
         uint16_t channelr = (uint16_t)ConvertBitIntoBytes(&LCW_bits[56], 16);
         fprintf (stderr, "Ch: %04X TG: %d; ", channelt, group1);
+        UNUSED(channelr);
       }
 
       else if (lc_format == 0x45)
@@ -257,6 +260,7 @@ void p25_lcw (dsd_opts * opts, dsd_state * state, uint8_t LCW_bits[], uint8_t ir
         uint16_t channelr = (uint16_t)ConvertBitIntoBytes(&LCW_bits[48], 16);
         uint8_t cfva = (uint8_t)ConvertBitIntoBytes(&LCW_bits[64], 4);
         fprintf (stderr, " - RFSS %d Site %d CH %04X", rfssid, siteid, channelt);
+        UNUSED2(lra, channelr);
 
         //debug print only
         // fprintf (stderr, "\n  ");

--- a/src/p25p1_block.cpp
+++ b/src/p25p1_block.cpp
@@ -201,7 +201,6 @@ static uint16_t crc16_ok(const uint8_t bits[], unsigned int len) {
 int crc16_lb_bridge (int payload[190], int len)
 {
   int err = -2;
-  uint16_t crc = -2;
   uint8_t buf[190] = {0};
 
   for (int i = 0; i < len+16; i++) //add +16 here so we load the entire frame but only run crc on the len portion
@@ -264,7 +263,6 @@ static uint16_t crc12_ok(const uint8_t bits[], unsigned int len) {
 int crc12_xb_bridge (int payload[190], int len)
 {
   int err = -5;
-  uint16_t crc = -2;
   uint8_t buf[190] = {0};
 
   //need to load up the 12 crc bits as well, else it will fail on the check, but not on the crc calc

--- a/src/p25p1_hdu.c
+++ b/src/p25p1_hdu.c
@@ -26,6 +26,7 @@ read_dibit (dsd_opts* opts, dsd_state* state, char* output, int* status_count, i
 {
     int dibit;
     int status;
+    UNUSED(status);
 
     if (*status_count == 35) {
 
@@ -65,7 +66,6 @@ read_dibit_update_analog_data (dsd_opts* opts, dsd_state* state, char* output, u
         AnalogSignal* analog_signal_array, int* analog_signal_index)
 {
   unsigned int i;
-  unsigned int debug_left, debug_right;
 
   for (i=0; i<count; i+=2)
     {
@@ -215,9 +215,8 @@ correct_golay_dibits_6(char* corrected_hex_data, int hex_count, AnalogSignal* an
 void
 processHDU(dsd_opts* opts, dsd_state* state)
 {
-  char mi[73], mfid[9], algid[9], kid[17], tgid[17], tmpstr[255];
+  char mi[73], mfid[9], algid[9], kid[17], tgid[17];
   int i, j;
-  long talkgroup;
   int algidhex, kidhex;
   char hex[6];
   int status_count;
@@ -225,6 +224,7 @@ processHDU(dsd_opts* opts, dsd_state* state)
   unsigned long long int mihex1, mihex2, mihex3;
   char hex_data[20][6];    // Data in hex-words (6 bit words). A total of 20 hex words.
   char hex_parity[16][6];  // Parity of the data, again in hex-word format. A total of 16 parity hex words.
+  UNUSED4(mfid, tgid, status, mihex3);
 
   int irrecoverable_errors;
 

--- a/src/p25p1_heuristics.c
+++ b/src/p25p1_heuristics.c
@@ -315,7 +315,6 @@ int estimate_symbol(int rf_mod, P25Heuristics* heuristics, int previous_dibit, i
 static void debug_print_symbol_heuristics(int previous_dibit, int dibit, SymbolHeuristics* sh)
 {
     float mean, sd;
-    int k;
     int n;
 
     n = sh->count;

--- a/src/p25p1_ldu.c
+++ b/src/p25p1_ldu.c
@@ -67,6 +67,7 @@ process_IMBE (dsd_opts* opts, dsd_state* state, int* status_count)
   int j, dibit, status;
   char imbe_fr[8][23];
   const int *w, *x, *y, *z;
+  UNUSED(status);
 
   w = iW;
   x = iX;

--- a/src/p25p1_ldu1.c
+++ b/src/p25p1_ldu1.c
@@ -196,6 +196,7 @@ processLDU1 (dsd_opts* opts, dsd_state* state)
       int status;
       status = getDibit (opts, state) + '0';
       // TODO: do something useful with the status bits...
+      UNUSED(status);
   }
 
   // Error correct the hex_data using Reed-Solomon hex_parity

--- a/src/p25p1_ldu2.c
+++ b/src/p25p1_ldu2.c
@@ -33,6 +33,7 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
   int algidhex, kidhex;
   unsigned long long int mihex1, mihex2, mihex3;
   int status_count;
+  UNUSED(mihex3);
 
   char hex_data[16][6];    // Data in hex-words (6 bit words). A total of 16 hex words.
   char hex_parity[8][6];   // Parity of the data, again in hex-word format. A total of 12 parity hex words.
@@ -203,6 +204,7 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
       int status;
       status = getDibit (opts, state) + '0';
       // TODO: do something useful with the status bits...
+      UNUSED(status);
   }
 
   // Error correct the hex_data using Reed-Solomon hex_parity

--- a/src/p25p1_mdpu.c
+++ b/src/p25p1_mdpu.c
@@ -64,14 +64,13 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
   int flushing_bits[196]; //for flushing the trellis state machine
   memset (flushing_bits, 0, sizeof(flushing_bits));
 
-  int i, j, k, b, x, y;
+  int i, j, k, x;
   int ec[3]; //error value returned from (block_deinterleave)
   int err[2]; //error value returned from ccrc16 or crc32
   memset (ec, -2, sizeof(ec));
   memset (err, -2, sizeof(err));
 
   int skipdibit = 14; //initial status dibit will occur at 14, then add 36 each time it occurs
-  int protectbit = 0;
   int MFID = 0xFF; //Manufacturer ID
 
   uint8_t mpdu_byte[36];
@@ -214,12 +213,14 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
       int channelt = (mpdu_byte[15] << 8) | mpdu_byte[16];
       int channelr = (mpdu_byte[17] << 8) | mpdu_byte[18];
       int ssc =  mpdu_byte[19];
+      UNUSED3(res_a, res_b, ssc);
       fprintf (stderr, "%s",KYEL);
       fprintf (stderr, "\n Network Status Broadcast MBT - Extended \n");
       fprintf (stderr, "  LRA [%02X] WACN [%05lX] SYSID [%03X] NAC [%03llX]\n", lra, wacn, sysid, state->p2_cc);
       fprintf (stderr, "  CHAN-T [%04X] CHAN-R [%04X]", channelt, channelr);
       long int ct_freq = process_channel_to_freq(opts, state, channelt);
       long int cr_freq = process_channel_to_freq(opts, state, channelr);
+      UNUSED(cr_freq);
       
       state->p25_cc_freq = ct_freq;
       state->p25_cc_is_tdma = 0; //flag off for CC tuning purposes when system is qpsk
@@ -293,6 +294,7 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
 			int group = (mpdu_byte[18] << 8) | mpdu_byte[19];
 			long int freq1 = 0;
 			long int freq2 = 0;
+      UNUSED2(source, freq2);
       fprintf (stderr, "%s\n ",KYEL);
       if (svc & 0x80) fprintf (stderr, " Emergency");
       if (svc & 0x40) fprintf (stderr, " Encrypted");
@@ -391,6 +393,7 @@ void processMPDU(dsd_opts * opts, dsd_state * state)
 			long int target = (mpdu_byte[19] << 16) |(mpdu_byte[20] << 8) | mpdu_byte[21];
 			long int freq1 = 0;
 			long int freq2 = 0;
+      UNUSED(freq2);
       fprintf (stderr, "%s\n ",KYEL);
       if (svc & 0x80) fprintf (stderr, " Emergency");
       if (svc & 0x40) fprintf (stderr, " Encrypted");

--- a/src/p25p1_tdu.c
+++ b/src/p25p1_tdu.c
@@ -32,6 +32,7 @@ processTDU (dsd_opts* opts, dsd_state* state)
         int status;
         status = getDibit (opts, state) + '0';
         // TODO: do something useful with the status bits...
+        UNUSED(status);
     }
     
     //reset some strings -- since its a tdu, blank out any call strings, only want during actual call

--- a/src/p25p1_tdulc.c
+++ b/src/p25p1_tdulc.c
@@ -305,6 +305,7 @@ processTDULC (dsd_opts* opts, dsd_state* state)
       int status;
       status = getDibit (opts, state) + '0';
       // TODO: do something useful with the status bits...
+      UNUSED(status);
   }
 
   // Put the corrected data into the DSD structures

--- a/src/p25p1_tsbk.c
+++ b/src/p25p1_tsbk.c
@@ -41,7 +41,7 @@ void processTSBK(dsd_opts * opts, dsd_state * state)
   int flushing_bits[196]; //for flushing the trellis state machine
   memset (flushing_bits, 0, sizeof(flushing_bits));
   
-  int i, j, k, b, x, y;
+  int i, j, k, x;
   int ec = -2; //error value returned from (block_deinterleave)
   int err = -2; //error value returned from crc16_lb_bridge
   int skipdibit = 14; //initial status dibit will occur at 14, then add 36 each time it occurs

--- a/src/p25p2_frame.c
+++ b/src/p25p2_frame.c
@@ -375,6 +375,7 @@ void process_ISCH (dsd_opts * opts, dsd_state * state)
 			int free = (isch_decoded >> 2) & 0x1;
 			int isch_loc = (isch_decoded >> 3) & 0x3;
 			int chan_num = (isch_decoded >> 5) & 0x3;
+			UNUSED2(uf_count, free);
 			state->p2_vch_chan_num = chan_num;
 
 			//old rules for entire superframe worth
@@ -674,7 +675,6 @@ void process_P2_DUID (dsd_opts * opts, dsd_state * state)
 	int err_counter = 0;
 
 	//add time to mirror printFrameSync
-  	time_t now;
   	char * getTime(void) //get pretty hh:mm:ss timestamp
   	{
     	time_t t = time(NULL);

--- a/src/p25p2_vpdu.c
+++ b/src/p25p2_vpdu.c
@@ -89,6 +89,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 		if (MAC[1+len_a] == 0xA3 && MAC[2+len_a] == 0x90)
 		{
 			int mfid = MAC[2+len_a];
+			UNUSED(mfid);
 			int channel  = (MAC[5+len_a] << 8) | MAC[6+len_a];
 			int sgroup = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			long int freq = 0;
@@ -168,6 +169,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int channelr = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			int sgroup = (MAC[9+len_a] << 8) | MAC[10+len_a];
 			long int freq = 0;
+			UNUSED2(mfid, channelr);
 			fprintf (stderr, "\n MFID90 Group Regroup Channel Grant - Explicit");
 			fprintf (stderr, "\n  CHAN [%04X] Group [%d][%04X]", channel, sgroup, sgroup);
 			freq = process_channel_to_freq (opts, state, channel);
@@ -546,7 +548,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			long int freq1t = 0;
 			long int freq1r = 0;
 			long int freq2t = 0;
-			long int freq2r = 0;
+			UNUSED(freq1r);
 
 			fprintf (stderr, "\n Group Voice Channel Grant Update Multiple - Explicit");
 			fprintf (stderr, "\n  SVC [%02X] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc1, channelt1, channelr1, group1, group1);
@@ -973,6 +975,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int group = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			long int freq1 = 0;
 			long int freq2 = 0;
+			UNUSED(freq2);
 
 			fprintf (stderr, "\n");
 
@@ -1079,7 +1082,6 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 		//Authentication Response - Abbreviated
 		if (MAC[1+len_a] == 0x78) 
 		{
-			int res1 = 0; //don't really care about this value, just setting it to zero
 			int source = (MAC[8+len_a] << 16) | (MAC[9+len_a] << 8) | MAC[10+len_a];
 			fprintf (stderr, "\n Authentication Response - Abbreviated \n");
 			fprintf (stderr, "  Source [%08d][%06X] ", source, source);
@@ -1378,6 +1380,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int len_grg = MAC[3+len_a] & 0x3F;
 			int grg = MAC[4+len_a] >> 5; //3 bits
 			int ssn = MAC[4+len_a] & 0x1F; //5 bits
+			UNUSED(ssn);
 			fprintf (stderr, "\n MFIDA4 Group Regroup Explicit Encryption Command\n");
 			//fprintf (stderr, " LEN [%02X] GRG [%02X]\n", len_grg, grg);
 			if (grg & 0x2) //if grg == wgid //&0x2 according to OP25
@@ -1389,6 +1392,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 				int t2 = (MAC[12+len_a] << 8) | MAC[13+len_a];
 				int t3 = (MAC[14+len_a] << 8) | MAC[15+len_a];
 				int t4 = (MAC[16+len_a] << 8) | MAC[17+len_a];
+				UNUSED4(t1, t2, t3, t4);
 				fprintf (stderr, "  SG [%05d] KEY [%04X] ALG [%02X]\n  ", sg, key, alg);
 				int a = 0;
 				int wgid = 0;
@@ -1512,6 +1516,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int channel = (MAC[7+len_a] << 8) | MAC[8+len_a];
 			int sysclass = MAC[9+len_a];
 			int lcolorcode = ((MAC[10+len_a] & 0xF) << 8) | MAC[11+len_a];
+			UNUSED(sysclass);
 			fprintf (stderr, "\n Network Status Broadcast - Abbreviated \n");
 			fprintf (stderr, "  LRA [%02X] WACN [%05X] SYSID [%03X] NAC [%03X] CHAN-T [%04X]", lra, lwacn, lsysid, lcolorcode, channel);
 			state->p25_cc_freq = process_channel_to_freq (opts, state, channel);
@@ -1541,6 +1546,7 @@ void process_MAC_VPDU(dsd_opts * opts, dsd_state * state, int type, unsigned lon
 			int channelr = (MAC[9+len_a] << 8) | MAC[10+len_a];
 			int sysclass = MAC[9+len_a];
 			int lcolorcode = ((MAC[12+len_a] & 0xF) << 8) | MAC[13+len_a];
+			UNUSED(sysclass);
 			fprintf (stderr, "\n Network Status Broadcast - Extended \n");
 			fprintf (stderr, "  LRA [%02X] WACN [%05X] SYSID [%03X] NAC [%03X] CHAN-T [%04X] CHAN-R [%04X]", lra, lwacn, lsysid, lcolorcode, channelt, channelr);
 			state->p25_cc_freq = process_channel_to_freq (opts, state, channelt);

--- a/src/p25p2_xcch.c
+++ b/src/p25p2_xcch.c
@@ -41,16 +41,17 @@ void process_SACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[180]
 	int mco_a = 69;
 	//mco will tell us the number of octets to use in variable length MAC PDUs, need a table or something
 	mco_a = (payload[10] << 5) | (payload[11] << 4) | (payload[12] << 3) | (payload[13] << 2) | (payload[14] << 0) | (payload[15] << 0);
+	UNUSED3(mac_offset, b, mco_a);
 
 	//get the second mco after determining first message length, see what second mco is and plan accordingly
 	int mco_b = 69;
+	UNUSED(mco_b);
 
 	//attempt CRC12 check to validate or reject PDU
 	int err = -2;
 	if (state->p2_is_lcch == 0)
 	{
-		int len =
-		err = crc12_xb_bridge(payload, 180-12);
+		int err = crc12_xb_bridge(payload, 180-12);
 		if (err != 0) //CRC Failure, warn or skip.
 		{
 			if (SMAC[1] == 0x0) //NULL PDU Check, pass if NULL type
@@ -334,6 +335,7 @@ void process_FACCH_MAC_PDU (dsd_opts * opts, dsd_state * state, int payload[156]
 	opcode = (payload[0] << 2) | (payload[1] << 1) | (payload[2] << 0);
 	int mac_offset = 0;
 	mac_offset = (payload[3] << 2) | (payload[4] << 1) | (payload[5] << 0);
+	UNUSED(mac_offset);
 
 	//attempt CRC check to validate or reject PDU
 	int err = -2;

--- a/src/provoice.c
+++ b/src/provoice.c
@@ -23,7 +23,6 @@ void processProVoice (dsd_opts * opts, dsd_state * state)
 
   uint8_t spacer_bit[8]; //check this value to see if its a status thing (like P25 P1)
   memset (spacer_bit, 0, sizeof (spacer_bit));
-  uint8_t spacer = 0;
   uint16_t bf = 0; //the 16-bit value in-between imbe 2 and imbe 3 that is usually 2175
 
   fprintf (stderr," VOICE");

--- a/src/rtl_sdr_fm.cpp
+++ b/src/rtl_sdr_fm.cpp
@@ -908,12 +908,10 @@ static unsigned int chars_to_int(unsigned char* buf) {
 }
 
 static void *socket_thread_fn(void *arg) {
-	struct demod_state *d = static_cast<demod_state*>(arg);
-  int r, n;
-  int sockfd, newsockfd, portno;
-  socklen_t clilen;
+  int n;
+  int sockfd;
   unsigned char buffer[5];
-  struct sockaddr_in serv_addr, cli_addr;
+  struct sockaddr_in serv_addr;
 
 	sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 
@@ -935,7 +933,7 @@ static void *socket_thread_fn(void *arg) {
 
 	fprintf (stderr, "Main socket started! :-) Tuning enabled on UDP/%d \n", port);
 
-	int new_freq, demod_type, new_squelch, new_gain, agc_mode;
+	int new_freq;
 
 	while((n = read(sockfd,buffer,5)) != 0) {
 		if(buffer[0] == 0) {
@@ -962,7 +960,6 @@ void rtlsdr_sighandler()
 
 void open_rtlsdr_stream(dsd_opts *opts)
 {
-  struct sigaction sigact;
   int r;
 	rtl_bandwidth =  opts->rtl_bandwidth * 1000; //reverted back to straight value
 	bandwidth_multiplier = (bandwidth_divisor / rtl_bandwidth);

--- a/src/x2tdma_data.c
+++ b/src/x2tdma_data.c
@@ -29,6 +29,7 @@ processX2TDMAdata (dsd_opts * opts, dsd_state * state)
   char cc[4];
   int aiei;
   char bursttype[5];
+  UNUSED4(syncdata, cachdata, cc, aiei);
 
 #ifdef X2TDMA_DUMP
   int k;

--- a/src/x2tdma_voice.c
+++ b/src/x2tdma_voice.c
@@ -39,6 +39,7 @@ processX2TDMAvoice (dsd_opts * opts, dsd_state * state)
   int mutecurrentslot;
   int algidhex, kidhex;
   int msMode;
+  UNUSED5(lcformat, mfid, lcinfo, cachdata, parity);
 
 #ifdef X2TDMA_DUMP
   int k;


### PR DESCRIPTION
There are a lot of changes but most of them are trivial. I tried to preserve those variables with special meaning and which, kind of, document the code. Also, I added `-Wunused-but-set-variable` and `-Wunused-variable` flags in CMake. A good practice is to add `-Werror` at the same time but for the moment `ysf.c` and `trellis.cpp` are not ready for this and I don't want to mess with them.