### PR TITLE
Set exitflag before cleaning up

### DIFF
--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -1334,6 +1334,9 @@ if (opts->audio_out_type == 0)
 void
 cleanupAndExit (dsd_opts * opts, dsd_state * state)
 {
+  // Signal that everything should shutdown.
+  exitflag = 1;
+
   noCarrier (opts, state);
   if (opts->wav_out_f != NULL)
   {


### PR DESCRIPTION
This will signal to all related code that the program is about to exit.

Closes #138.