### PR TITLE
Fix warnings from -Wempty-body, -Wunused-label, and -Wpointer-sign

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,8 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 ADD_EXECUTABLE(dsd-fme ${SRCS} ${HEADERS})
 TARGET_LINK_LIBRARIES(dsd-fme ${LIBS})
 
-target_compile_options(dsd-fme PRIVATE -Wunused-but-set-variable -Wunused-variable -Wunused-parameter)
+target_compile_options(dsd-fme PRIVATE -Wunused-but-set-variable -Wunused-variable -Wunused-parameter
+                       -Wempty-body -Wunused-label $<$<COMPILE_LANGUAGE:C>:-Wpointer-sign>)
 
 include(GNUInstallDirs)
 install(TARGETS dsd-fme DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/include/descramble.h
+++ b/include/descramble.h
@@ -52,7 +52,7 @@ int traceBack (int * out, int * m_pathMemory0, int * m_pathMemory1, int * m_path
 					state = S2; // lower path
 				} else {
 					state = S0; // upper path
-				}; // end else - if
+				} // end else - if
 				out[loop]=0;
 				break;
 			
@@ -61,7 +61,7 @@ int traceBack (int * out, int * m_pathMemory0, int * m_pathMemory1, int * m_path
 					state = S2; // lower path
 				} else {
 					state = S0; // upper path
-				}; // end else - if
+				} // end else - if
 				out[loop]=1;
 				break;
 			
@@ -70,7 +70,7 @@ int traceBack (int * out, int * m_pathMemory0, int * m_pathMemory1, int * m_path
 					state = S3; // lower path
 				} else {
 					state = S1; // upper path
-				}; // end else - if
+				} // end else - if
 				out[loop]=0;
 				break;
 			
@@ -79,12 +79,12 @@ int traceBack (int * out, int * m_pathMemory0, int * m_pathMemory1, int * m_path
 					state = S3; // lower path
 				} else {
 					state = S1; // upper path
-				}; // end else - if
+				} // end else - if
 				out[loop]=1;
 				break;
 			
-		}; // end switch
-	}; // end for
+		} // end switch
+	} // end for
 
 return(length);
 }; // end function

--- a/include/dsd.h
+++ b/include/dsd.h
@@ -1021,7 +1021,7 @@ void dmr_locn (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
 //dmr alg stuff
 void dmr_alg_reset (dsd_opts * opts, dsd_state * state);
 void dmr_alg_refresh (dsd_opts * opts, dsd_state * state);
-void dmr_late_entry_mi_fragment (dsd_opts * opts, dsd_state * state, uint8_t vc, char ambe_fr[4][24], char ambe_fr2[4][24], char ambe_fr3[4][24]);
+void dmr_late_entry_mi_fragment (dsd_opts * opts, dsd_state * state, uint8_t vc, uint8_t ambe_fr[4][24], uint8_t ambe_fr2[4][24], uint8_t ambe_fr3[4][24]);
 void dmr_late_entry_mi (dsd_opts * opts, dsd_state * state);
 
 //handle Single Burst (Voice Burst F) or Reverse Channel Signalling

--- a/include/fcs.h
+++ b/include/fcs.h
@@ -75,7 +75,7 @@ for (loop=0; loop < size; loop++) {
 
 	m_crc = (m_crc >> 8) ^ ccittTab[tmp];
 
-}; // end for
+} // end for
 
 // calculate and save crc-value in fields 54 and 55 of dvframe
 m_crc = ~m_crc;

--- a/src/dmr_bs.c
+++ b/src/dmr_bs.c
@@ -24,14 +24,14 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
   char redundancyB[36];
 
   //memcpy of ambe_fr for late entry
-  char m1[4][24];
-  char m2[4][24];
-  char m3[4][24];
+  uint8_t m1[4][24];
+  uint8_t m2[4][24];
+  uint8_t m3[4][24];
   
   const int *w, *x, *y, *z;
   char sync[25];
   char syncdata[48];
-  char EmbeddedSignalling[16];
+  unsigned char EmbeddedSignalling[16];
 
   uint8_t emb_ok = 0;
   uint8_t tact_okay = 0;
@@ -82,7 +82,7 @@ void dmrBS (dsd_opts * opts, dsd_state * state)
   short int skipcount = 0;
 
   //cach
-  char cachdata[25]; 
+  uint8_t cachdata[25];
   int cachInterleave[24] =
   {0, 7, 8, 9, 1, 10,
    11, 12, 2, 13, 14,
@@ -503,9 +503,9 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
   memset (ambe_fr3, 0, sizeof(ambe_fr3));
 
   //memcpy of ambe_fr for late entry
-  char m1[4][24];
-  char m2[4][24];
-  char m3[4][24];
+  uint8_t m1[4][24];
+  uint8_t m2[4][24];
+  uint8_t m3[4][24];
 
   const int *w, *x, *y, *z;
   char sync[25];
@@ -516,7 +516,7 @@ void dmrBSBootstrap (dsd_opts * opts, dsd_state * state)
 
   uint8_t internalslot;
 
-  char cachdata[25]; 
+  uint8_t cachdata[25];
   int cachInterleave[24] =
   {0, 7, 8, 9, 1, 10,
   11, 12, 2, 13, 14,

--- a/src/dmr_csbk.c
+++ b/src/dmr_csbk.c
@@ -1086,7 +1086,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
             }
           } //end tuning
 
-          SKIPCAP: ;
+          // SKIPCAP: ;
           //debug print
           if (fl == 1 && opts->payload == 1)
           {
@@ -1491,7 +1491,7 @@ void dmr_cspdu (dsd_opts * opts, dsd_state * state, uint8_t cs_pdu_bits[], uint8
     } //end Hytera XPT section
 
   }
-  END:
+
   fprintf (stderr, "%s", KNRM);  
 
 }

--- a/src/dmr_data.c
+++ b/src/dmr_data.c
@@ -25,7 +25,7 @@ dmr_data_sync (dsd_opts * opts, dsd_state * state)
   int *dibit_p;
   char sync[25];
   char syncdata[48];
-  char cachdata[25];
+  uint8_t cachdata[25];
   UNUSED(syncdata);
 
   uint8_t burst;

--- a/src/dmr_dburst.c
+++ b/src/dmr_dburst.c
@@ -595,7 +595,7 @@ void dmr_data_burst_handler(dsd_opts * opts, dsd_state * state, uint8_t info[196
   if (is_ras == 1) CRCCorrect = crc_original_validity;
 
   //start printing relevant fec/crc/ras messages, don't print on idle or MBC continuation blocks (handled in dmr_block.c)
-  if (IrrecoverableErrors == 0 && CRCCorrect == 1 && databurst != 0x09 && databurst != 0x05) ; //fprintf(stderr, "(CRC OK)");
+  // if (IrrecoverableErrors == 0 && CRCCorrect == 1 && databurst != 0x09 && databurst != 0x05) fprintf(stderr, "(CRC OK)");
 
   // if (IrrecoverableErrors == 0 && CRCCorrect == 0 && databurst != 0x09 && databurst != 0x05)
   // {

--- a/src/dmr_le.c
+++ b/src/dmr_le.c
@@ -9,7 +9,7 @@
 #include "dsd.h"
 
 //gather ambe_fr mi fragments for processing
-void dmr_late_entry_mi_fragment (dsd_opts * opts, dsd_state * state, uint8_t vc, char ambe_fr[4][24], char ambe_fr2[4][24], char ambe_fr3[4][24])
+void dmr_late_entry_mi_fragment (dsd_opts * opts, dsd_state * state, uint8_t vc, uint8_t ambe_fr[4][24], uint8_t ambe_fr2[4][24], uint8_t ambe_fr3[4][24])
 {
   
   uint8_t slot = state->currentslot;

--- a/src/dmr_ms.c
+++ b/src/dmr_ms.c
@@ -20,14 +20,14 @@ void dmrMS (dsd_opts * opts, dsd_state * state)
   char ambe_fr4[4][24];
 
   //memcpy of ambe_fr for late entry
-  char m1[4][24];
-  char m2[4][24];
-  char m3[4][24];
+  uint8_t m1[4][24];
+  uint8_t m2[4][24];
+  uint8_t m3[4][24];
 
   const int *w, *x, *y, *z;
   char sync[25];
   char syncdata[48];
-  char EmbeddedSignalling[16];
+  uint8_t EmbeddedSignalling[16];
 
   //cach
   char cachdata[25]; 
@@ -371,9 +371,9 @@ void dmrMSBootstrap (dsd_opts * opts, dsd_state * state)
   memset (ambe_fr3, 0, sizeof(ambe_fr3));
 
   //memcpy of ambe_fr for late entry
-  char m1[4][24];
-  char m2[4][24];
-  char m3[4][24];
+  uint8_t m1[4][24];
+  uint8_t m2[4][24];
+  uint8_t m3[4][24];
 
   const int *w, *x, *y, *z;
 

--- a/src/dmr_pdu.c
+++ b/src/dmr_pdu.c
@@ -406,8 +406,6 @@ void dmr_lrrp (dsd_opts * opts, dsd_state * state, uint8_t block_len, uint8_t DM
     fprintf (stderr, "  Potential ARRP/LRRP Report (Debug): 0x%02X", report);
   }
 
-  LRRP_END:
-
   fprintf (stderr, "%s", KNRM);
   
 }

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -1822,15 +1822,15 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
   }
 
   //NXDN
-  if (state->nxdn_last_rid > 0 && state->nxdn_last_rid != src);
+  if (state->nxdn_last_rid > 0 && state->nxdn_last_rid != src)
   {
     src = state->nxdn_last_rid;
   }
-  if (state->nxdn_last_ran > -1 && state->nxdn_last_ran != rn);
+  if (state->nxdn_last_ran > -1 && state->nxdn_last_ran != rn)
   {
     rn = state->nxdn_last_ran;
   }
-  if (state->nxdn_last_tg > 0 && state->nxdn_last_tg != tgn);
+  if (state->nxdn_last_tg > 0 && state->nxdn_last_tg != tgn)
   {
     tgn = state->nxdn_last_tg;
   }

--- a/src/nxdn_deperm.c
+++ b/src/nxdn_deperm.c
@@ -448,12 +448,12 @@ void nxdn_deperm_facch2_udch(dsd_opts * opts, dsd_state * state, uint8_t bits[34
 	if (crc == check)
 	{ 
 		if (type == 1) NXDN_Elements_Content_decode(opts, state, 1, f2u_message_buffer);
-		if (type == 0) ; //need handling for user data (text messages and AVL)
+		if (type == 0) {} //need handling for user data (text messages and AVL)
 	} 
 	else if (opts->aggressive_framesync == 0)
 	{
 		if (type == 1) NXDN_Elements_Content_decode(opts, state, 0, f2u_message_buffer);
-		if (type == 0) ; //need handling for user data (text messages and AVL)
+		if (type == 0) {} //need handling for user data (text messages and AVL)
 	} 
 
 	if (opts->payload == 1)
@@ -847,12 +847,12 @@ void nxdn_deperm_facch3_udch2(dsd_opts * opts, dsd_state * state, uint8_t bits[2
 	if (crc[0] == check[0] && crc[1] == check[1])
 	{
 		if (type == 1) NXDN_Elements_Content_decode(opts, state, 1, trellis_buf);
-		if (type == 0) ; //need handling for user data (text messages and AVL)
+		if (type == 0) {} //need handling for user data (text messages and AVL)
 	}  
 	else if (opts->aggressive_framesync == 0) 
 	{
 		if (type == 1) NXDN_Elements_Content_decode(opts, state, 0, trellis_buf);
-		if (type == 0) ; //need handling for user data (text messages and AVL)
+		if (type == 0) {} //need handling for user data (text messages and AVL)
 	}
 
 	if (opts->payload == 1)

--- a/src/nxdn_element.c
+++ b/src/nxdn_element.c
@@ -666,16 +666,16 @@ void NXDN_decode_Alias(dsd_opts * opts, dsd_state * state, uint8_t * Message)
     //since we are zeroing out the blocks on tx_rel and other conditions, better to just set nothing to bad Alias bytes
     //tends to zero out otherwise already good blocks set in a previous repitition.
     if (Alias1 > 0x19 && Alias1 < 0x7F) sprintf (state->nxdn_alias_block_segment[blocknumber-1][0], "%c", Alias1);
-    else ;// sprintf (state->nxdn_alias_block_segment[blocknumber-1][0], "%c", 32); //space
+    //else sprintf (state->nxdn_alias_block_segment[blocknumber-1][0], "%c", 32); //space
 
     if (Alias2 > 0x19 && Alias2 < 0x7F) sprintf (state->nxdn_alias_block_segment[blocknumber-1][1], "%c", Alias2);
-    else ; //sprintf (state->nxdn_alias_block_segment[blocknumber-1][1], "%c", 0); //space
+    //else sprintf (state->nxdn_alias_block_segment[blocknumber-1][1], "%c", 0); //space
 
     if (Alias3 > 0x19 && Alias3 < 0x7F) sprintf (state->nxdn_alias_block_segment[blocknumber-1][2], "%c", Alias3);
-    else ; //sprintf (state->nxdn_alias_block_segment[blocknumber-1][2], "%c", 0); //space
+    //else sprintf (state->nxdn_alias_block_segment[blocknumber-1][2], "%c", 0); //space
 
     if (Alias4 > 0x19 && Alias4 < 0x7F) sprintf (state->nxdn_alias_block_segment[blocknumber-1][3], "%c", Alias4);
-    else ; //sprintf (state->nxdn_alias_block_segment[blocknumber-1][3], "%c", 0); //space
+    //else sprintf (state->nxdn_alias_block_segment[blocknumber-1][3], "%c", 0); //space
   }
 
   //crc errs in one repitition may occlude an otherwise good alias, so test and change if needed

--- a/src/p25p1_hdu.c
+++ b/src/p25p1_hdu.c
@@ -215,7 +215,8 @@ correct_golay_dibits_6(char* corrected_hex_data, int hex_count, AnalogSignal* an
 void
 processHDU(dsd_opts* opts, dsd_state* state)
 {
-  char mi[73], mfid[9], algid[9], kid[17], tgid[17];
+  uint8_t mi[73];
+  char mfid[9], algid[9], kid[17], tgid[17];
   int i, j;
   int algidhex, kidhex;
   char hex[6];

--- a/src/p25p1_ldu1.c
+++ b/src/p25p1_ldu1.c
@@ -28,7 +28,7 @@ processLDU1 (dsd_opts* opts, dsd_state* state)
 {
   // extracts IMBE frames from LDU frame
   int i;
-  char lcformat[9], mfid[9], lcinfo[57];
+  uint8_t lcformat[9], mfid[9], lcinfo[57];
   char lsd1[9], lsd2[9];
 
   int status_count;

--- a/src/p25p1_ldu2.c
+++ b/src/p25p1_ldu2.c
@@ -28,7 +28,8 @@ processLDU2 (dsd_opts * opts, dsd_state * state)
 {
   // extracts IMBE frames from LDU frame
   int i;
-  char mi[73], algid[9], kid[17];
+  uint8_t mi[73];
+  char algid[9], kid[17];
   char lsd1[9], lsd2[9];
   int algidhex, kidhex;
   unsigned long long int mihex1, mihex2, mihex3;

--- a/src/p25p1_tdulc.c
+++ b/src/p25p1_tdulc.c
@@ -216,7 +216,7 @@ void
 processTDULC (dsd_opts* opts, dsd_state* state)
 {
   int i;
-  char lcinfo[57], lcformat[9], mfid[9];
+  uint8_t lcinfo[57], lcformat[9], mfid[9];
 
   int status_count;
 


### PR DESCRIPTION
Again changes are mostly trivial but not those in dsd_ncurses.c. They did change the logic but the changes seem to be what was originally intended. @lwvmobile, please pay attention before merging.