### PR TITLE
Auto install for Arch/Manjaro

### DIFF
--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+clear
+echo DSD-FME Digital Speech Decoder - Florida Man Edition Auto Installer For Arch Linux
+echo This will install the required packages, clone, build, and install DSD-FME only.
+echo This has been tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal.
+
+read -p "Press enter to continue"
+
+sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsnd filegit wget rtlsdr
+
+echo Installing itpp 4.3.1 from Arch Strike (Tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal)
+wget https://mirror.archstrike.org/x86_64/archstrike/itpp-4.3.1-3-x86_64.pkg.tar.xz
+sudo pacman -U itpp-4.3.1-3-x86_64.pkg.tar.xz
+sudo rm -R itpp-4.3.1-3-x86_64.pkg.tar.xz
+
+git clone https://github.com/lwvmobile/dsd-fme
+### For branch v2.1b - git clone --branch v2.1b https://github.com/lwvmobile/dsd-fme
+cd dsd-fme
+sudo cp tone8.wav /usr/share/
+sudo cp tone24.wav /usr/share/
+sudo cp tone48.wav /usr/share/
+sudo chmod 777 /usr/share/tone8.wav
+sudo chmod 777 /usr/share/tone24.wav
+sudo chmod 777 /usr/share/tone48.wav
+mkdir build
+cd build
+cmake ..
+make -j `nproc`
+sudo make install
+sudo ldconfig
+sudo rm -R dsd-fme
+
+echo Any issues, Please report to either
+echo https://github.com/lwvmobile/dsd-fme/issues
+echo https://forums.radioreference.com/threads/dsd-fme.438137/

--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -23,10 +23,10 @@ cmake ..
 make -j `nproc`
 sudo make install
 sudo ldconfig
-sudo cp /usr/local/lib/libmbe.a /usr/lib/libmbe.a
-sudo cp /usr/local/lib/libmbe.so /usr/lib/libmbe.so
-sudo cp /usr/local/lib/libmbe.so.1 /usr/lib/libmbe.so.1 # ldconfig: /usr/lib/libmbe.so.1 is not a symbolic link
-sudo cp /usr/local/lib/libmbe.so.1.3 /usr/lib/libmbe.so.1.3
+#sudo cp /usr/local/lib/libmbe.a /usr/lib/libmbe.a
+sudo cp /usr/local/lib/libmbe.so /usr/lib/libmbe.so #this is the only one we need to copy 
+#sudo cp /usr/local/lib/libmbe.so.1 /usr/lib/libmbe.so.1
+#sudo cp /usr/local/lib/libmbe.so.1.3 /usr/lib/libmbe.so.1.3
 cd ..
 cd ..
 

--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -4,7 +4,16 @@ echo DSD-FME Digital Speech Decoder - Florida Man Edition Auto Installer For Arc
 echo This will install the required packages, clone, build, and install DSD-FME only.
 echo This has been tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal.
 
-read -p "Press enter to continue"
+echo MBELib is considered a requirement on this build.
+echo You must view this notice prior to continuing. 
+echo The Patent Notice can be found at the site below.
+echo https://github.com/lwvmobile/mbelib#readme
+echo Please confirm that you have viewed the patent notice by entering y below.
+echo
+echo y/N
+read ANSWER
+Y='y'
+if [[ $Y == $ANSWER ]]; then
 
 sudo pacman -Syu #always run a full update first, partial upgrades aren't supported in Arch -- including downloading dependencies, that may require an updated dependency, and breaks same dependency on another package, a.k.a, dependency hell
 sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget rtl-sdr
@@ -51,3 +60,8 @@ sudo rm -R dsd-fme
 echo Any issues, Please report to either
 echo https://github.com/lwvmobile/dsd-fme/issues
 echo https://forums.radioreference.com/threads/dsd-fme.438137/
+
+else
+echo
+echo Sorry, you cannot build DSD-FME without acknowledging the Patent Notice.
+fi

--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -3,7 +3,7 @@ clear
 echo DSD-FME Digital Speech Decoder - Florida Man Edition Auto Installer For Arch Linux
 echo This will install the required packages, clone, build, and install DSD-FME only.
 echo This has been tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal.
-
+echo 
 echo MBELib is considered a requirement on this build.
 echo You must view this notice prior to continuing. 
 echo The Patent Notice can be found at the site below.

--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -6,16 +6,34 @@ echo This has been tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal.
 
 read -p "Press enter to continue"
 
-sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsnd filegit wget rtlsdr
+sudo pacman -Syu #always run a full update first, partial upgrades aren't supported in Arch -- including downloading dependencies, that may require an updated dependency, and breaks same dependency on another package, a.k.a, dependency hell
+sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget rtl-sdr
 
-echo Installing itpp 4.3.1 from Arch Strike (Tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal)
+echo Installing itpp 4.3.1 from Arch Strike --Tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal
 wget https://mirror.archstrike.org/x86_64/archstrike/itpp-4.3.1-3-x86_64.pkg.tar.xz
 sudo pacman -U itpp-4.3.1-3-x86_64.pkg.tar.xz
 sudo rm -R itpp-4.3.1-3-x86_64.pkg.tar.xz
 
+git clone https://github.com/lwvmobile/mbelib
+cd mbelib
+git checkout ambe_tones
+mkdir build
+cd build
+cmake ..
+make -j `nproc`
+sudo make install
+sudo ldconfig
+sudo cp /usr/local/lib/libmbe.a /usr/lib/libmbe.a
+sudo cp /usr/local/lib/libmbe.so /usr/lib/libmbe.so
+sudo cp /usr/local/lib/libmbe.so.1 /usr/lib/libmbe.so.1 # ldconfig: /usr/lib/libmbe.so.1 is not a symbolic link
+sudo cp /usr/local/lib/libmbe.so.1.3 /usr/lib/libmbe.so.1.3
+cd ..
+cd ..
+
 git clone https://github.com/lwvmobile/dsd-fme
 ### For branch v2.1b - git clone --branch v2.1b https://github.com/lwvmobile/dsd-fme
 cd dsd-fme
+git checkout v2.1b
 sudo cp tone8.wav /usr/share/
 sudo cp tone24.wav /usr/share/
 sudo cp tone48.wav /usr/share/

--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -16,7 +16,7 @@ Y='y'
 if [[ $Y == $ANSWER ]]; then
 
 sudo pacman -Syu #always run a full update first, partial upgrades aren't supported in Arch -- including downloading dependencies, that may require an updated dependency, and breaks same dependency on another package, a.k.a, dependency hell
-sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget rtl-sdr
+sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget
 
 echo Installing itpp 4.3.1 from Arch Strike --Tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal
 wget https://mirror.archstrike.org/x86_64/archstrike/itpp-4.3.1-3-x86_64.pkg.tar.xz

--- a/examples/Install_Notes.md
+++ b/examples/Install_Notes.md
@@ -11,8 +11,18 @@ wget https://raw.githubusercontent.com/lwvmobile/dsd-fme/main/download-and-insta
 chmod +x download-and-install.sh
 ./download-and-install.sh
 ```
-f
-If you have dependencies already installed (i.e. need a fresh clean install on a system with DSD-FME already or using system other than Debian/Ubuntu, etc), please run this instead:
+
+### Arch Based Distros:
+
+```
+wget https://raw.githubusercontent.com/lwvmobile/dsd-fme/main/download-and-install-Arch.sh
+chmod +x download-and-install-Arch.sh
+./download-and-install-Arch.sh
+```
+
+### Other:
+
+If you have dependencies already installed, please run this instead:
 
 ```
 wget https://raw.githubusercontent.com/lwvmobile/dsd-fme/main/download-and-install-nodeps.sh
@@ -34,8 +44,20 @@ sudo apt install libpulse-dev pavucontrol libsndfile1-dev libfftw3-dev liblapack
 Fedora 36/37 -- from https://github.com/lwvmobile/dsd-fme/issues/99
 
 ```
+sudo dnf update
 sudo dnf install libsndfile-devel fftw-devel lapack-devel rtl-sdr-devel pulseaudio-libs-devel libusb-devel cmake git ncurses ncurses-devel gcc wget pavucontrol gcc-c++
 ```
+
+Arch -- https://github.com/lwvmobile/dsd-fme/issues/153 and https://github.com/lwvmobile/dsd-fme/issues/153
+
+```
+sudo pacman -Syu
+sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget rtl-sdr
+wget https://mirror.archstrike.org/x86_64/archstrike/itpp-4.3.1-3-x86_64.pkg.tar.xz
+sudo pacman -U itpp-4.3.1-3-x86_64.pkg.tar.xz
+```
+
+
 ## Headless Ubuntu Server/Pi
 
 If running headless, swap out pavucontrol for pulsemixer, and also install pulseaudio as well. Attempting to install pavucontrol in a headless environment may attempt to install a minimal desktop environment. Note: Default behavior of pulseaudio in a headless environment may be to be muted, so check by opening pulsemixer and unmuting and routing audio appropriately.


### PR DESCRIPTION
Tested on Arch Linux 2023.08.01 and Manjaro XFCE 22.1.3 Minimal and everything works great!

Arch Linux
`https://archlinux.org`

Manjaro
`https://download.manjaro.org/xfce/22.1.3/manjaro-xfce-22.1.3-minimal-230529-linux61.iso`

Notes for compiling

(1) When compiling and building **mbelib**, It seems to work ok and look like is installed but when running .... Its also the same issue with itpp.

[archlinux ~]# dsd-fme -h
`dsd-fme: error while loading shared libraries: libmbe.so.1: cannot open shared object file: No such file or directory`

Lucky mbelib is in arch linux repo and can be installed by pacman.

`sudo pacman -S mbelib`