### PR TITLE
Tested on Arch 2023.12.01

### DIFF
--- a/download-and-install-Arch.sh
+++ b/download-and-install-Arch.sh
@@ -4,7 +4,7 @@ cdir=$(pwd)
 clear
 printf "Digital Speech Decoder: Florida Man Edition - Auto Installer For Arch Linux\n
 This will install the required packages, clone, build, and install DSD-FME only.
-This has been tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal.\n
+This has been tested on Arch 2023.12.01 and Manjaro XFCE 22.1.3 Minimal.\n
 MBELib is considered a requirement on this build.
 You must view the Patent Notice prior to continuing.
 The Patent Notice can be found at the site below.
@@ -14,8 +14,10 @@ read -p "Have you viewed the patent notice? y/N " ANSWER
 ANSWER=$(printf "$ANSWER"|tr '[:upper:]' '[:lower:]')
 if [ "$ANSWER" = "y" ]; then
 
+  curl -s "https://archlinux.org/mirrorlist/?country=all&protocol=http&ip_version=4&use_mirror_status=on" | sed -e 's/^#Server/Server/' -e '/^#/d' > /etc/pacman.d/mirrorlist
+
   sudo pacman -Syu #always run a full update first, partial upgrades aren't supported in Arch -- including downloading dependencies, that may require an updated dependency, and breaks same dependency on another package, a.k.a, dependency hell
-  sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget
+  sudo pacman -S libpulse cmake ncurses lapack perl fftw rtl-sdr codec2 base-devel libsndfile git wget nano curl
 
   printf "Installing itpp 4.3.1 from Arch Strike --Tested on Arch 2023.08.01 and Manjaro XFCE 22.1.3 Minimal\n"
   wget https://mirror.archstrike.org/x86_64/archstrike/itpp-4.3.1-3-x86_64.pkg.tar.xz


### PR DESCRIPTION
1) Tested on Arch 2023.12.01 and works fine without no errors.
2) Added Mirror incase there is any new/deads URLs.

Note, For a country in US mirror's

```
curl -s "https://archlinux.org/mirrorlist/?country=US&protocol=http&ip_version=4&use_mirror_status=on" | sed -e 's/^#Server/Server/' -e '/^#/d' > /etc/pacman.d/mirrorlist
```

UK mirrors

```
curl -s "https://archlinux.org/mirrorlist/?country=GB&protocol=http&ip_version=4&use_mirror_status=on" | sed -e 's/^#Server/Server/' -e '/^#/d' > /etc/pacman.d/mirrorlist
```