### PR TITLE
fix nxdn scramber roll on facch1 after superframe

### DIFF
--- a/src/nxdn_frame.c
+++ b/src/nxdn_frame.c
@@ -419,6 +419,11 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
 		//roll the voice scrambler LFSR here if key available to advance seed (usually just needed on NXDN96)
 		if (state->nxdn_cipher_type == 0x1 && state->R != 0) 
 		{
+			if (state->payload_miN == 0)
+			{
+				state->payload_miN = state->R;
+			}
+
 			char ambe_temp[49] = {0};
 			char ambe_d[49] = {0};
 			for (int i = 0; i < 4; i++)
@@ -436,6 +441,11 @@ void nxdn_frame (dsd_opts * opts, dsd_state * state)
 		//roll the voice scrambler LFSR here if key available to advance seed -- half rotation on a facch steal
 		if (state->nxdn_cipher_type == 0x1 && state->R != 0)
 		{
+			if (state->payload_miN == 0)
+			{
+				state->payload_miN = state->R;
+			}
+
 			char ambe_temp[49] = {0};
 			char ambe_d[49] = {0};
 			for (int i = 0; i < 2; i++)


### PR DESCRIPTION
On new superframe scrambler seed is reset here:
https://github.com/lwvmobile/dsd-fme/blob/audio_work/src/nxdn_deperm.c#L343
https://github.com/lwvmobile/dsd-fme/blob/audio_work/src/nxdn_deperm.c#L819

If we get a facch1 right after a superframe, then LFSRN won't be able to advance the seed, because the payload_miN is still zero.
