### PR TITLE
mbe err2 set when processing Ambe3600

### DIFF
--- a/src/dsd_mbe.c
+++ b/src/dsd_mbe.c
@@ -383,10 +383,9 @@ processMbeFrame (dsd_opts * opts, dsd_state * state, char imbe_fr[8][23], char a
   else if ((state->synctype == 28) || (state->synctype == 29)) //was 8 and 9
   {
 
-    state->errs = mbe_eccAmbe3600x2450C0 (ambe_fr);
-    //state->errs2 = state->errs;
+    state->errs2 = state->errs = mbe_eccAmbe3600x2450C0 (ambe_fr);
     mbe_demodulateAmbe3600x2450Data (ambe_fr);
-    state->errs2 = mbe_eccAmbe3600x2450Data (ambe_fr, ambe_d);
+    state->errs2 += mbe_eccAmbe3600x2450Data (ambe_fr, ambe_d);
 
     if ( (state->nxdn_cipher_type == 0x01 && state->R > 0) ||
           (state->M == 1 && state->R > 0) )


### PR DESCRIPTION
set err2 to err
then add to err2 the result from mbe_eccAmbe3600x2450Data 
Same as here: https://github.com/lwvmobile/mbelib/blob/master/ambe3600x2450.c#L667