### PR TITLE
ldconfig for Debian 12

### DIFF
--- a/download-and-install.sh
+++ b/download-and-install.sh
@@ -28,15 +28,16 @@ if [ "$ANSWER" = "y" ]; then
   make -j $(nproc)
   sudo make install
   sudo ldconfig
+# make install for Debian 12
   cd $cdir
   git clone https://github.com/lwvmobile/dsd-fme
   cd dsd-fme
-  #git checkout audio_work
   mkdir build
   cd build
   cmake ..
   make -j $(nproc)
   sudo make install
+  # make install (for Debian 12 as ldconfig dos not work on Debian 12 for x64)
   sudo ldconfig
 else
   printf "\nSorry, you cannot build DSD-FME without acknowledging the Patent Notice.\nExiting...\n\n"


### PR DESCRIPTION
Notes for Debian 12 x64.

When running 
```
root@debian:/tmp/mbelib/build# ldconfig
**bash: ldconfig: command not found**
```

When running

`make install`

works fine, Also had to use "su" before any commands.