### PR TITLE
EDACS: Add MT1 value / logging for analog group calls

### DIFF
--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -645,7 +645,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         fprintf (stderr, "%s", KNRM);
 
         //this is working now with the new import setup
-        if (opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block 
+        if (opts->trunk_tune_group_calls == 1 && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block 
         {
           if (lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
           {
@@ -661,7 +661,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             if (opts->use_rigctl == 1)
             {
               if (opts->setmod_bw != 0 ) SetModulation(opts->rigctl_sockfd, opts->setmod_bw); 
-      		    SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because the lcn index starts at zero
+              SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because the lcn index starts at zero
               state->edacs_tuned_lcn = lcn;
               opts->p25_is_tuned = 1;
               //debug testing (since I don't have EDACS standard w/ Analog nearby)
@@ -804,7 +804,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
 
         //this is working now with the new import setup
-        if (opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block
+        if (opts->trunk_tune_group_calls == 1 && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block
         {
           if (lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
           {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -645,7 +645,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         fprintf (stderr, "%s", KNRM);
 
         //this is working now with the new import setup
-        if (opts->trunk_tune_group_calls == 1 && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block 
+        if (opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block 
         {
           if (lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
           {
@@ -661,7 +661,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             if (opts->use_rigctl == 1)
             {
               if (opts->setmod_bw != 0 ) SetModulation(opts->rigctl_sockfd, opts->setmod_bw); 
-              SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because the lcn index starts at zero
+      		    SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because the lcn index starts at zero
               state->edacs_tuned_lcn = lcn;
               opts->p25_is_tuned = 1;
               //debug testing (since I don't have EDACS standard w/ Analog nearby)
@@ -804,7 +804,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
 
         //this is working now with the new import setup
-        if (opts->trunk_tune_group_calls == 1 && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block
+        if (opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block
         {
           if (lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
           {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -600,8 +600,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
       //   fprintf (stderr, " Kick Command?");
       // }
       //Voice Call Grant Update
-      // mt1 0x3 is Digital group voice call, 0x2 Group Data Channel, 0x1 TDMA call
-      else if (mt1 >= 0x1 && mt1 <= 0x3)
+      // mt1 0x6 is analog group voice call, 0x3 is Digital group voice call, 0x2 Group Data Channel, 0x1 TDMA call
+      else if ((mt1 >= 0x1 && mt1 <= 0x3) || mt1 == 0x6)
       {
         //LCNs greater than 26 are considered status values, "Busy, Queue, Deny, etc"
         if (lcn > state->edacs_lcn_count && lcn < 26) 
@@ -641,6 +641,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         if (mt1 == 0x1) fprintf (stderr, " TDMA Call"); //never observed, wonder if any EDACS systems ever carried a TDMA signal (X2-TDMA?)
         if (mt1 == 0x2) fprintf (stderr, " Group Data Call"); //Never Seen this one before
         if (mt1 == 0x3) fprintf (stderr, " Digital Call"); //ProVoice, this is what we always get on SLERS EA
+        if (mt1 == 0x6) fprintf (stderr, " Analog Call"); //analog, to at least log that we recognize it
         fprintf (stderr, "%s", KNRM);
 
         //this is working now with the new import setup


### PR DESCRIPTION
Add logging for the EDACS EA MT1 value `0x6` which indicates an analog call.