### PR TITLE
EDACS: fixes and improvements to EA analog and i-call parsing

### DIFF
--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3618,7 +3618,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               printw ("Target [%8lld] Source [%8lld] I-Call", call_matrix[j][2] - 100000, call_matrix[j][3]);
             else
               // Group call
-              printw ("Target [%8lld] Source [%8lld]", call_matrix[j][2] - 100000, call_matrix[j][3]);
+              printw ("Target [%8lld] Source [%8lld]", call_matrix[j][2], call_matrix[j][3]);
           }
           else 
           {

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3449,10 +3449,10 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
         if (state->ea_mode == 1) {
           if (call_matrix[i][2] > 100000)
             // I-Call
-            printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2] - 100000, call_matrix[i][3] );
+            printw (" TGT [%8lld] SRC [%8lld] I-Call", call_matrix[i][2] - 100000, call_matrix[i][3] );
           else
             // Group call
-            printw (" TG [%5lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
+            printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
         }
         else
         {
@@ -3482,10 +3482,10 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
         if (state->ea_mode == 1) {
           if (call_matrix[i][2] > 100000)
             // I-Call
-            printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2] - 100000, call_matrix[i][3] );
+            printw (" TGT [%8lld] SRC [%8lld] I-Call", call_matrix[i][2] - 100000, call_matrix[i][3] );
           else
             // Group call
-            printw (" TG [%5lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
+            printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
         }
         else
         {
@@ -3615,11 +3615,10 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           {
             if (call_matrix[j][2] > 100000)
               // I-Call
-              printw ("Target [%8lld] ", call_matrix[j][2] - 100000);
+              printw ("Target [%8lld] Source [%8lld] I-Call", call_matrix[j][2] - 100000, call_matrix[j][3]);
             else
               // Group call
-              printw ("Group [%8lld] ", call_matrix[j][2]);
-            printw ("Source [%8lld] ", call_matrix[j][3]);
+              printw ("Target [%8lld] Source [%8lld]", call_matrix[j][2] - 100000, call_matrix[j][3]);
           }
           else 
           {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -714,8 +714,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //if we are using allow/whitelist mode, then write 'B' to mode for block - no allow/whitelist support for i-calls
         if (opts->trunk_use_allow_list == 1) sprintf (mode, "%s", "B");
 
-        if (mt2 == 0x10) fprintf (stderr, " Analog Call");
-        if (mt2 == 0x14) fprintf (stderr, " Digital Call");
+        if (mt2 == 0xA) fprintf (stderr, " Analog Call");
+        if (mt2 == 0xE) fprintf (stderr, " Digital Call");
         fprintf (stderr, "%s", KNRM);
 
         //this is working now with the new import setup
@@ -727,7 +727,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             if (opts->dmr_stereo_wav == 1 && (opts->use_rigctl == 1 || opts->audio_in_type == 3))
             {
               sprintf (opts->wav_out_file, "./WAV/%s %s EDACS Site %lld TGT %d SRC %d.wav", getDateE(), timestr, state->edacs_site_id, target, source);
-              if (mt2 == 0x14) //digital
+              if (mt2 == 0xE) //digital
                 openWavOutFile (opts, state);
               else //analog
                 openWavOutFile48k (opts, state); //
@@ -741,7 +741,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
               state->edacs_tuned_lcn = lcn;
               opts->p25_is_tuned = 1;
               //
-              if (mt2 == 0x10)
+              if (mt2 == 0xA) //analog
                 edacs_analog(opts, state, target, lcn);
             }
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -651,7 +651,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //this is working now with the new import setup
         if (opts->trunk_tune_group_calls == 1 && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block 
         {
-          if (lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
+          if (lcn > 0 && lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
           {
             //openwav file and do per call right here, should probably check as well to make sure we have a valid trunking method active (rigctl, rtl)
             if (opts->dmr_stereo_wav == 1 && (opts->use_rigctl == 1 || opts->audio_in_type == 3))
@@ -721,7 +721,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //this is working now with the new import setup
         if (opts->trunk_tune_private_calls == 1 && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block 
         {
-          if (lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
+          if (lcn > 0 && lcn < 26 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
           {
             //openwav file and do per call right here, should probably check as well to make sure we have a valid trunking method active (rigctl, rtl)
             if (opts->dmr_stereo_wav == 1 && (opts->use_rigctl == 1 || opts->audio_in_type == 3))

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -602,8 +602,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
       //   fprintf (stderr, " Kick Command?");
       // }
       //Voice Call Grant Update
-      // mt1 0x6 is analog group voice call, 0x3 is Digital group voice call, 0x2 Group Data Channel, 0x1 TDMA call
-      else if ((mt1 >= 0x1 && mt1 <= 0x3) || mt1 == 0x6)
+      // mt1 0x12 is analog group voice call, 0x3 is Digital group voice call, 0x2 Group Data Channel, 0x1 TDMA call
+      else if ((mt1 >= 0x1 && mt1 <= 0x3) || mt1 == 0x12)
       {
         lcn = (fr_1t & 0x3E0000000) >> 29;
 
@@ -645,7 +645,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         if (mt1 == 0x1) fprintf (stderr, " TDMA Call"); //never observed, wonder if any EDACS systems ever carried a TDMA signal (X2-TDMA?)
         if (mt1 == 0x2) fprintf (stderr, " Group Data Call"); //Never Seen this one before
         if (mt1 == 0x3) fprintf (stderr, " Digital Call"); //ProVoice, this is what we always get on SLERS EA
-        if (mt1 == 0x6) fprintf (stderr, " Analog Call"); //analog, to at least log that we recognize it
+        if (mt1 == 0x12) fprintf (stderr, " Analog Call"); //analog, to at least log that we recognize it
         fprintf (stderr, "%s", KNRM);
 
         //this is working now with the new import setup
@@ -657,7 +657,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             if (opts->dmr_stereo_wav == 1 && (opts->use_rigctl == 1 || opts->audio_in_type == 3))
             {
               sprintf (opts->wav_out_file, "./WAV/%s %s EDACS Site %lld TG %d SRC %d.wav", getDateE(), timestr, state->edacs_site_id, group, source);
-              if (mt1 != 0x6) //digital
+              if (mt1 != 0x12) //digital
                 openWavOutFile (opts, state);
               else //analog
                 openWavOutFile48k (opts, state); //
@@ -670,7 +670,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
               SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because the lcn index starts at zero
               state->edacs_tuned_lcn = lcn;
               opts->p25_is_tuned = 1;
-              if (mt1 == 0x6) //analog
+              if (mt1 == 0x12) //analog
                 edacs_analog(opts, state, group, lcn);
             }
 
@@ -690,9 +690,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
         }
       }
       //I-Call Grant Update
-      else if (mt1 == 0x10)
+      else if (mt1 == 0x4)
       {
-        lcn = (fr_4t & 0xFF00000000) >> 32;
+        lcn = (fr_4t & 0x1F00000000) >> 32;
 
         //LCNs greater than 26 are considered status values, "Busy, Queue, Deny, etc"
         if (lcn > state->edacs_lcn_count && lcn < 26) 
@@ -702,7 +702,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
         int target = (fr_1t & 0xFFFFF000) >> 12;
         int source = (fr_4t & 0xFFFFF000) >> 12;
-        if (target != 0)  state->lasttg = target + 100000; //Use IDs > 100000 to represent i-call targets to differentiate from TGs
+        if (target != 0) state->lasttg = target + 100000; //Use IDs > 100000 to represent i-call targets to differentiate from TGs
         if (source != 0) state->lastsrc = source;
         if (lcn != 0)    state->edacs_vc_lcn = lcn;
         fprintf (stderr, "%s", KGRN);

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -760,6 +760,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
           }
         }
       }
+      //Login
+      else if (mt1 == 0x19)
+      {
+        int group  = (fr_1t & 0xFFFF000) >> 12;
+        int source = (fr_4t & 0xFFFFF000) >> 12;
+        fprintf (stderr, " Login Group [%08d] Source [%08d]", group, source);
+      }
       else //print frames for debug/analysis
       {
         fprintf (stderr, " FR_1 [%010llX]", fr_1t);


### PR DESCRIPTION
Improvements:
- confirm LCN is not 0 before trying to tune to it
- process "login" messages on CC

Fixes:
- typo that resulted in incorrect identification of i-call type
- typo that shows incorrect TG IDs in the call log