### PR TITLE
EDACS: Rewrite Standard/Networked parsing per TIA/EIA TSB 69.3

### DIFF
--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3490,9 +3490,9 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     }
     for (i = 1; i <= state->edacs_lcn_count; i++)
     {
-      //shim 443 afs in here for display purposes
-      int a  = (call_matrix[i][3] >> 7) & 0xF; 
-      int fs = call_matrix[i][3] & 0x7F;
+      // Compute 4:4:3 AFS for display purposes only
+      int a  = (call_matrix[i][2] >> 7) & 0xF;
+      int fs = call_matrix[i][2] & 0x7F;
       printw ("| - LCN [%02d][%.06lf] MHz", i, (double)state->trunk_lcn_freq[i-1]/1000000); 
       
       //print Control Channel on LCN line with the current Control Channel
@@ -3519,7 +3519,15 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
         }
         else
         {
-          printw (" AFS [%03lld][%02d-%03d]", call_matrix[i][3], a, fs );
+          if (call_matrix[i][2] + 1 == 0)
+            // System all-call
+            printw (" TGT [SYSTEM][SYSTEM] SRC [%5lld] All-Call", call_matrix[i][3] );
+          else if (call_matrix[i][2] > 10000)
+            // I-Call
+            printw (" TGT [%6lld][------] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
+          else
+            // Group call
+            printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
         }
         for (int k = 0; k < state->group_tally; k++)
         {
@@ -3555,7 +3563,15 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
         }
         else
         {
-          printw (" AFS [%03lld][%02d-%03d]", call_matrix[i][3], a, fs );
+          if (call_matrix[i][2] + 1 == 0)
+            // System all-call
+            printw (" TGT [SYSTEM][SYSTEM] SRC [%5lld] All-Call", call_matrix[i][3] );
+          else if (call_matrix[i][2] > 10000)
+            // I-Call
+            printw (" TGT [%6lld][------] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
+          else
+            // Group call
+            printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
         }
         for (int k = 0; k < state->group_tally; k++)
         {
@@ -3691,9 +3707,18 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           }
           else 
           {
-            int a  = (call_matrix[j][3] >> 7) & 0xF; 
-            int fs = call_matrix[j][3] & 0x7F;
-            printw (" AFS [%03lld][%02d-%03d]", call_matrix[j][3], a, fs );
+            // Compute 4:4:3 AFS for display purposes only
+            int a  = (call_matrix[j][2] >> 7) & 0xF; 
+            int fs = call_matrix[j][2] & 0x7F;
+            if (call_matrix[j][2] + 1 == 0)
+              // System all-call
+              printw ("Target [SYSTEM][SYSTEM] Source [%5lld] All-Call", call_matrix[j][3]);
+            else if (call_matrix[j][2] > 10000)
+              // I-Call
+              printw ("Target [%6lld][------] Source [%5lld] I-Call", call_matrix[j][2] - 10000, call_matrix[j][3]);
+            else
+              // Group call
+              printw ("Target [%6lld][%02d-%03d] Source [%5lld]", call_matrix[j][2], a, fs, call_matrix[j][3]);
           }          
           //test
           for (int k = 0; k < state->group_tally; k++)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1130,7 +1130,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           if (is_individual == 0) fprintf (stderr, " Group [%04d]", target);
           else                    fprintf (stderr, " LID [%05d]", target);
           fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
-          if (mt_c == 0 || mt_c == 1) fprintf (stderr, " [message trunking]");
+          if (is_tx_trunk == 0) fprintf (stderr, " [message trunking]");
           if (is_emergency == 1)
           {
             fprintf (stderr, "%s", KRED);
@@ -1298,7 +1298,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int adj_site_id = (fr_1t & 0x1F0000) >> 16;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Adjacent Site Control Channel :: Site ID [%02X][%03d] Index [%1d] LCN [%02d]%s", adj_site_id, adj_site_id, adj_site_index, adj_cc_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " Adjacent Site Control Channel :: Site ID [%02X][%03d] Index [%1d] LCN [%02d]%s", adj_site_id, adj_site_id, adj_site_index, adj_cc_lcn, get_lcn_status_string(adj_cc_lcn));
             if (adj_site_id == 0 && adj_site_index == 0)      fprintf (stderr, " [Adjacency Table Reset]");
             else if (adj_site_id != 0 && adj_site_index == 0) fprintf (stderr, " [Priority System Definition]");
             else if (adj_site_id == 0 && adj_site_index != 0) fprintf (stderr, " [Adjacencies Table Length Definition]");
@@ -1393,7 +1393,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int target = (fr_1t & 0x3FFF000) >> 12;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Unit Enable/Disable ::", target);
+            fprintf (stderr, " Unit Enable/Disable ::");
             if (qualifier == 0x0)      fprintf (stderr, " [Temporary Disable]");
             else if (qualifier == 0x1) fprintf (stderr, " [Corrupt Personality]");
             else if (qualifier == 0x2) fprintf (stderr, " [Revoke Logical ID]");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1028,7 +1028,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int group = (fr_1t & 0x7FF000) >> 12;
 
         fprintf (stderr, "%s", KYEL);
-        fprintf (stderr, " Voice Group Channel Assignment :: Group [%04d] LID [%05d] LCN [%02d]", group, lid, lcn);
+        fprintf (stderr, " Voice Group Channel Assignment :: Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
         if (is_tx_trunk == 0) fprintf (stderr, " [message trunking]");
         if (is_emergency == 1)
         {
@@ -1058,7 +1058,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else                       fprintf (stderr, " Group [%04d]", group);
         if (is_from_lid == 1) fprintf (stderr, " -->");
         else                  fprintf (stderr, " <--");
-        fprintf (stderr, " Port [%02d] LCN [%02d]", port, lcn);
+        fprintf (stderr, " Port [%02d] LCN [%02d]%s", port, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
       }
       //Login Acknowledge (6.2.4.4)
@@ -1100,7 +1100,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           else             fprintf (stderr, " [Reserved]");
           if (is_individual_id == 1) fprintf (stderr, " LID [%05d]", lid);
           else                       fprintf (stderr, " Group [%04d]", group);
-          fprintf (stderr, " LCN [%02d]", lcn);
+          fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
           fprintf (stderr, "%s", KNRM);
 
           // TODO: Actually process the call
@@ -1127,8 +1127,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
           else                    fprintf (stderr, " Voice Individual Channel Update ::");
           if (is_digital == 0) fprintf (stderr, " Analog");
           else                 fprintf (stderr, " Digital");
-          if (is_individual == 0) fprintf (stderr, " Group [%04d] LCN [%02d]", target, lcn);
-          else                    fprintf (stderr, " LID [%05d] LCN [%02d]", target, lcn);
+          if (is_individual == 0) fprintf (stderr, " Group [%04d]", target);
+          else                    fprintf (stderr, " LID [%05d]", target);
+          fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
           if (mt_c == 0 || mt_c == 1) fprintf (stderr, " [message trunking]");
           if (is_emergency == 1)
           {
@@ -1256,7 +1257,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, " Individual Call Channel Assignment :: Type");
           if (call_type == 1) fprintf (stderr, " [Voice]");
           else                fprintf (stderr, " [Reserved]");
-          fprintf (stderr, " Caller [%05d] Callee [%05d] LCN [%02d]", source, target, lcn);
+          fprintf (stderr, " Caller [%05d] Callee [%05d] LCN [%02d]%s", source, target, lcn, get_lcn_status_string(lcn));
           if (is_tx_trunk == 0) fprintf (stderr, " [message trunking]");
           fprintf (stderr, "%s", KNRM);
 
@@ -1273,7 +1274,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, " Console ");
           if (is_drop == 0) fprintf (stderr, " Unkey");
           else              fprintf (stderr, " Drop");
-          fprintf (stderr, " :: LID [%05d] LCN [%02d]", lid, lcn);
+          fprintf (stderr, " :: LID [%05d] LCN [%02d]%s", lid, lcn, get_lcn_status_string(lcn));
           fprintf (stderr, "%s", KNRM);
         }
         //Use MT-D
@@ -1297,7 +1298,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int adj_site_id = (fr_1t & 0x1F0000) >> 16;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Adjacent Site Control Channel :: Site ID [%02X][%03d] Index [%1d] LCN [%02d]", adj_site_id, adj_site_id, adj_site_index, adj_cc_lcn);
+            fprintf (stderr, " Adjacent Site Control Channel :: Site ID [%02X][%03d] Index [%1d] LCN [%02d]%s", adj_site_id, adj_site_id, adj_site_index, adj_cc_lcn, get_lcn_status_string(lcn));
             if (adj_site_id == 0 && adj_site_index == 0)      fprintf (stderr, " [Adjacency Table Reset]");
             else if (adj_site_id != 0 && adj_site_index == 0) fprintf (stderr, " [Priority System Definition]");
             else if (adj_site_id == 0 && adj_site_index != 0) fprintf (stderr, " [Adjacencies Table Length Definition]");
@@ -1372,7 +1373,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int group = (fr_1t & 0x7FF000) >> 12;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Assignment to Auxiliary CC :: Group [%04d] Aux CC LCN [%02d]", group, aux_cc_lcn);
+            fprintf (stderr, " Assignment to Auxiliary CC :: Group [%04d] Aux CC LCN [%02d]%s", group, aux_cc_lcn, get_lcn_status_string(lcn));
             fprintf (stderr, "%s", KNRM);
           }
           //Initiate Test Call Command (6.2.4.16)
@@ -1411,7 +1412,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int site_id = (fr_1t & 0x1F000) >> 12;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Standard/Networked :: Site ID [%02X][%03d] Priority [%1d] CC LCN [%02d]", site_id, site_id, priority, cc_lcn);
+            fprintf (stderr, " Standard/Networked :: Site ID [%02X][%03d] Priority [%1d] CC LCN [%02d]%s", site_id, site_id, priority, cc_lcn, get_lcn_status_string(lcn));
             if (is_failsoft == 1)
             {
               fprintf (stderr, "%s", KRED);
@@ -1479,7 +1480,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             fprintf (stderr, " ::");
             if (qualifier == 1) fprintf (stderr, " [Voice]");
             else                fprintf (stderr, " [Reserved]");
-            fprintf (stderr, " LID [%05d] LCN [%02d]", lid, lcn);
+            fprintf (stderr, " LID [%05d] LCN [%02d]%s", lid, lcn, get_lcn_status_string(lcn));
             if (is_tx_trunk == 0) fprintf (stderr, " [message trunking]");
             fprintf (stderr, "%s", KNRM);
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1373,7 +1373,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int group = (fr_1t & 0x7FF000) >> 12;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Assignment to Auxiliary CC :: Group [%04d] Aux CC LCN [%02d]%s", group, aux_cc_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " Assignment to Auxiliary CC :: Group [%04d] Aux CC LCN [%02d]%s", group, aux_cc_lcn, get_lcn_status_string(aux_cc_lcn));
             fprintf (stderr, "%s", KNRM);
           }
           //Initiate Test Call Command (6.2.4.16)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -722,9 +722,6 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else                 fprintf (stderr, " Digital Group Call");
         if (is_update == 0) fprintf (stderr, " Assignment");
         else                fprintf (stderr, " Update");
-
-        fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
-
         fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
 
         //Trunking mode is correlated to (but not guaranteed to match) the type of call:

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -725,6 +725,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
         fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
 
+        fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]", group, source, lcn);
+
         //Trunking mode is correlated to (but not guaranteed to match) the type of call:
         // - emergency calls - usually message trunking
         // - normal calls - usually transmission trunking

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1027,14 +1027,14 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int is_tx_trunk = (fr_1t & 0x800000) >> 23;
         int group = (fr_1t & 0x7FF000) >> 12;
 
+        fprintf (stderr, "%s", KYEL);
+        fprintf (stderr, " Voice Group Channel Assignment :: Group [%04d] LID [%05d] LCN [%02d]", group, lid, lcn);
+        if (is_tx_trunk == 0) fprintf (stderr, " [message trunking]");
         if (is_emergency == 1)
         {
           fprintf (stderr, "%s", KRED);
           fprintf (stderr, " EMERGENCY");
         }
-        fprintf (stderr, "%s", KYEL);
-        fprintf (stderr, " Voice Group Channel Assignment :: Group [%04d] LID [%05d] LCN [%02d]", group, lid, lcn);
-        if (is_tx_trunk == 0) fprintf (stderr, " [message trunking]");
         fprintf (stderr, "%s", KNRM);
 
         // TODO: Actually process the call

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -725,7 +725,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
         fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
 
-        fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]", group, source, lcn);
+        fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
 
         //Trunking mode is correlated to (but not guaranteed to match) the type of call:
         // - emergency calls - usually message trunking


### PR DESCRIPTION
Basically a full rewrite of the Standard/Networked parsing to match the details in TIA/EIA TSB 69.3.

As yet untested due to lack of an EDACS Standard system near me.

Initial implementation only implements the existing functionality, and logs all other opcodes.