### PR TITLE
EDACS: ESK fixes, RE of standard channel assignments, cleanups

### DIFF
--- a/examples/Example_Usage.md
+++ b/examples/Example_Usage.md
@@ -180,9 +180,9 @@ M - toggle c4fm/qpsk 8/3 (phase 2 tdma control channel)
 R - start capturing symbol capture bin (date/time name file)
 r - stop capturing symbol capture bin
 spacebar - replay last symbol capture bin (captures must be stopped first)
-s - stop playing symbol capture bin or wav input file
+s - stop playing symbol capture bin or wav input file (lower s)
 P - start per call decoded wav files (Capital P)
-p - stop per call decoded wav files (Lower p)
+p - stop per call decoded wav files (lower p)
 t - toggle trunking (needs either rtl input, or rigctl connection)
 y - toggle scanner (needs either rtl input, or rigctl connection)
 1 - Toggle Voice Synthesis in TDMA Slot 1 or FDMA Conventional Voice
@@ -206,8 +206,8 @@ l - Hold TG in Slot 2 on TDMA Systems, or clear current hold
 C - Drop Call and Return to CC during trunking operation
 L - Manual Cycle Forward Channel Tuned when RIGCTL or using RTL input and channel csv loaded
 
-S - Toggle Between EDACS Standard/Network and Extended Addressing Mode
-A - Toggle EDACS ESK Mask
+S - Toggle between EDACS Standard/Network and Extended Addressing mode (Capital S)
+A - Toggle EDACS ESK Mask (none vs A0)
 
 ```
 

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3524,7 +3524,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             printw (" TGT [SYSTEM][SYSTEM] SRC [%5lld] All-Call", call_matrix[i][3] );
           else if (call_matrix[i][2] > 10000)
             // I-Call
-            printw (" TGT [%6lld][------] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
+            printw (" TGT [%6lld][ UNIT ] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
           else
             // Group call
             printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
@@ -3568,7 +3568,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             printw (" TGT [SYSTEM][SYSTEM] SRC [%5lld] All-Call", call_matrix[i][3] );
           else if (call_matrix[i][2] > 10000)
             // I-Call
-            printw (" TGT [%6lld][------] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
+            printw (" TGT [%6lld][ UNIT ] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
           else
             // Group call
             printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
@@ -3715,7 +3715,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               printw ("Target [SYSTEM][SYSTEM] Source [%5lld] All-Call", call_matrix[j][3]);
             else if (call_matrix[j][2] > 10000)
               // I-Call
-              printw ("Target [%6lld][------] Source [%5lld] I-Call", call_matrix[j][2] - 10000, call_matrix[j][3]);
+              printw ("Target [%6lld][ UNIT ] Source [%5lld] I-Call", call_matrix[j][2] - 10000, call_matrix[j][3]);
             else
               // Group call
               printw ("Target [%6lld][%02d-%03d] Source [%5lld]", call_matrix[j][2], a, fs, call_matrix[j][3]);

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1029,9 +1029,10 @@ void edacs(dsd_opts * opts, dsd_state * state)
       //deviation.
 
       //Reverse engineered from Quebec STM system; occurs immediately prior to Voice Group Channel Update
-      if (mt_a == 0x0)
+      if (mt_a == 0x0 || mt_a == 0x1)
       {
-        //LID and transmission trunking values are not confirmed, need validation
+        //Emergency, LID, and transmission trunking values are not confirmed, need validation
+        int is_emergency = (mt_a == 0x1) ? 1 : 0;
         int lid = ((fr_1t & 0x1FC0000000) >> 23) | ((fr_4t & 0xFE0000000) >> 29);
         int lcn = (fr_1t & 0x1F000000) >> 24;
         int is_tx_trunk = (fr_1t & 0x800000) >> 23;
@@ -1040,12 +1041,18 @@ void edacs(dsd_opts * opts, dsd_state * state)
         fprintf (stderr, "%s", KGRN);
         fprintf (stderr, " Voice Group Channel Assignment :: Analog Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
         if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
+        if (is_emergency == 1)
+        {
+          fprintf (stderr, "%s", KRED);
+          fprintf (stderr, " [EMERGENCY]");
+        }
         fprintf (stderr, "%s", KNRM);
 
         // TODO: Actually process the call
       }
       //Voice Group Channel Assignment (6.2.4.1)
       //Emergency Voice Group Channel Assignment (6.2.4.2)
+      //Reverse engineered as being for digital calls from San Antonio/Bexar Co system
       else if (mt_a == 0x2 || mt_a == 0x3)
       {
         int is_emergency = (mt_a == 0x3) ? 1 : 0;
@@ -1055,7 +1062,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int group = (fr_1t & 0x7FF000) >> 12;
 
         fprintf (stderr, "%s", KGRN);
-        fprintf (stderr, " Voice Group Channel Assignment :: Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " Voice Group Channel Assignment :: Digital Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
         if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
         if (is_emergency == 1)
         {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -532,7 +532,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
     // - KWHT - unknown/reserved
 
     //Account for ESK, if any
-    fr_1t = fr_1t ^ (((unsigned long long int)state->esk_mask) << 32);
+    unsigned long long int fr_esk_mask = ((unsigned long long int)state->esk_mask) << 32;
+    fr_1t = fr_1t ^ fr_esk_mask;
+    fr_4t = fr_4t ^ fr_esk_mask;
 
     //Start Extended Addressing Mode 
     if (state->ea_mode == 1)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1028,41 +1028,25 @@ void edacs(dsd_opts * opts, dsd_state * state)
       //April 1998. Where real world systems are found to diverge from this bulletin, please note the basis for the
       //deviation.
 
-      //Reverse engineered from Quebec STM system; occurs immediately prior to Voice Group Channel Update
-      if (mt_a == 0x0 || mt_a == 0x1)
-      {
-        //Emergency, LID, and transmission trunking values are not confirmed, need validation
-        int is_emergency = (mt_a == 0x1) ? 1 : 0;
-        int lid = ((fr_1t & 0x1FC0000000) >> 23) | ((fr_4t & 0xFE0000000) >> 29);
-        int lcn = (fr_1t & 0x1F000000) >> 24;
-        int is_tx_trunk = (fr_1t & 0x800000) >> 23;
-        int group = (fr_1t & 0x7FF000) >> 12;
-
-        fprintf (stderr, "%s", KGRN);
-        fprintf (stderr, " Voice Group Channel Assignment :: Analog Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
-        if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
-        if (is_emergency == 1)
-        {
-          fprintf (stderr, "%s", KRED);
-          fprintf (stderr, " [EMERGENCY]");
-        }
-        fprintf (stderr, "%s", KNRM);
-
-        // TODO: Actually process the call
-      }
+      //MT-A 0 and 1 as analog/digital mode indicator reverse engineered from Quebec STM and San Antonio/Bexar Co
+      //systems; occurs immediately prior to Voice Group Channel Update.
+      //
       //Voice Group Channel Assignment (6.2.4.1)
       //Emergency Voice Group Channel Assignment (6.2.4.2)
-      //Reverse engineered as being for digital calls from San Antonio/Bexar Co system
-      else if (mt_a == 0x2 || mt_a == 0x3)
+      if (mt_a == 0x0 || mt_a == 0x1 || mt_a == 0x2 || mt_a == 0x3)
       {
-        int is_emergency = (mt_a == 0x3) ? 1 : 0;
+        int is_digital = (mt_a == 0x2 || mt_a == 0x3) ? 1 : 0;
+        int is_emergency = (mt_a == 0x1 || mt_a == 0x3) ? 1 : 0;
         int lid = ((fr_1t & 0x1FC0000000) >> 23) | ((fr_4t & 0xFE0000000) >> 29);
         int lcn = (fr_1t & 0x1F000000) >> 24;
         int is_tx_trunk = (fr_1t & 0x800000) >> 23;
         int group = (fr_1t & 0x7FF000) >> 12;
 
         fprintf (stderr, "%s", KGRN);
-        fprintf (stderr, " Voice Group Channel Assignment :: Digital Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " Voice Group Channel Assignment ::");
+        if (is_digital == 0) fprintf (stderr, " Analog");
+        else                 fprintf (stderr, " Digital");
+        fprintf (stderr, " Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
         if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
         if (is_emergency == 1)
         {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1119,12 +1119,15 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int lid = (fr_1t & 0x3FFF000) >> 12;
           int group = (fr_1t & 0x7FF000) >> 12;
 
+          //Abstract away to a target, and be sure to check whether it's an individual call later
+          int target = (is_individual_id == 0) ? group : lid;
+          
           fprintf (stderr, "%s", KMAG);
           fprintf (stderr, " Interconnect Channel Assignment :: Type");
           if (mt_c == 0x2) fprintf (stderr, " [Voice]");
           else             fprintf (stderr, " [Reserved]");
-          if (is_individual_id == 1) fprintf (stderr, " LID [%05d]", lid);
-          else                       fprintf (stderr, " Group [%04d]", group);
+          if (is_individual_id == 1) fprintf (stderr, " LID [%05d]", target);
+          else                       fprintf (stderr, " Group [%04d]", target);
           fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
           fprintf (stderr, "%s", KNRM);
 


### PR DESCRIPTION
Apply ESK to both FR1 and FR4.

Additional RE of group voice channel assignment by mode (digital is MT-A 0/1, analog is MT-A 2/3).

Some cleanups.