### PR TITLE
EDACS: Standard display rewrite, parsing/RE fixes, tune i-calls and all-calls

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -702,6 +702,16 @@ typedef struct
   int edacs_cc_lcn; //current lcn for the edacs control channel
   int edacs_vc_lcn; //current lcn for any active vc (not the one we are tuned/tuning to)
   int edacs_tuned_lcn; //the vc we are currently tuned to...above variable is for updating all in the matrix
+  int edacs_vc_call_type; //the type of call on the given VC - see defines below
+
+  //flags for EDACS call type
+  #define EDACS_IS_VOICE        0x01
+  #define EDACS_IS_DIGITAL      0x02
+  #define EDACS_IS_EMERGENCY    0x04
+  #define EDACS_IS_GROUP        0x08
+  #define EDACS_IS_INDIVIDUAL   0x10
+  #define EDACS_IS_ALL_CALL     0x20
+  #define EDACS_IS_INTERCONNECT 0x40
 
   //trunking group and lcn freq list
   long int trunk_lcn_freq[26]; //max number on an EDACS system, should be enough on DMR too hopefully

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -1047,7 +1047,7 @@ initState (dsd_state * state)
 
   //edacs - may need to make these user configurable instead for stability on non-ea systems
   state->ea_mode = -1; //init on -1, 0 is standard, 1 is ea
-
+  state->edacs_vc_call_type = 0;
   state->esk_mask = 0x0; //esk mask value
   state->edacs_site_id = 0;
   state->edacs_lcn_count = 0;

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -2017,7 +2017,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
       //
       //If you MUST have perfectly-accurate source LIDs, look at the logged CC messages yourself - incorrect source LIDs
       //may be displayed if we miss an initial call channel assignment.
-      if (state->ea_mode == 1 || (state->lastsrc != 0 && call_matrix[state->edacs_vc_lcn][4] == state->edacs_vc_call_type))
+      if (state->ea_mode == 1 || (state->lastsrc != 0 || call_matrix[state->edacs_vc_lcn][4] != state->edacs_vc_call_type))
         call_matrix[state->edacs_vc_lcn][3] = state->lastsrc;
       call_matrix[state->edacs_vc_lcn][4] = state->edacs_vc_call_type;
       call_matrix[state->edacs_vc_lcn][5] = time(NULL);

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3511,54 +3511,23 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
         printw (" Control Channel");
         attroff (COLOR_PAIR(1));
       }
+
+      int print_call = 0;
       //print active calls on corresponding LCN line
       if ((i != state->edacs_cc_lcn) && time(NULL) - call_matrix[i][5] < 2)
       {
+        print_call = 3;
         attron (COLOR_PAIR(3));
-        if (state->ea_mode == 1) {
-          if (call_matrix[i][2] + 1 == 0)
-            // System all-call
-            printw (" TGT [ SYSTEM ] SRC [%8lld] All-Call", call_matrix[i][3] );
-          else if (call_matrix[i][2] > 100000)
-            // I-Call
-            printw (" TGT [%8lld] SRC [%8lld] I-Call", call_matrix[i][2] - 100000, call_matrix[i][3] );
-          else
-            // Group call
-            printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
-        }
-        else
-        {
-          if (call_matrix[i][2] + 1 == 0)
-            // System all-call
-            printw (" TGT [SYSTEM][SYSTEM] SRC [%5lld] All-Call", call_matrix[i][3] );
-          else if (call_matrix[i][2] > 10000)
-            // I-Call
-            printw (" TGT [%6lld][ UNIT ] SRC [%5lld] I-Call", call_matrix[i][2] - 10000, call_matrix[i][3] );
-          else
-            // Group call
-            printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
-        }
-        for (int k = 0; k < state->group_tally; k++)
-        {
-          if (state->group_array[k].groupNumber == call_matrix[i][2] && call_matrix[i][2] != 0)
-          {
-            printw (" [%s]", state->group_array[k].groupName);
-            printw ("[%s]", state->group_array[k].groupMode);
-            break;
-          }
-          else if (state->group_array[k].groupNumber == call_matrix[i][3] && call_matrix[i][3] != 0)
-          {
-            printw (" [%s]", state->group_array[k].groupName);
-            printw ("[%s]", state->group_array[k].groupMode);
-            break;
-          }
-        }
-        attroff (COLOR_PAIR(3));
       }
       //print dying or dead calls in red for x seconds longer
-      if ( (i != state->edacs_cc_lcn) && (time(NULL) - call_matrix[i][5] >= 2) && (time(NULL) - call_matrix[i][5] < 5) )
+      else if ( (i != state->edacs_cc_lcn) && (time(NULL) - call_matrix[i][5] >= 2) && (time(NULL) - call_matrix[i][5] < 5) )
       {
+        print_call = 2;
         attron (COLOR_PAIR(2));
+      }
+
+      if (print_call != 0)
+      {
         if (state->ea_mode == 1) {
           if (call_matrix[i][2] + 1 == 0)
             // System all-call
@@ -3597,9 +3566,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             break;
           }
         }
-        attroff (COLOR_PAIR(2));
+
+        if (print_call == 3)
+          attroff (COLOR_PAIR(3));
+        else if (print_call == 2)
+          attroff (COLOR_PAIR(2));
       }
-      if (i == state->edacs_tuned_lcn && opts->p25_is_tuned == 1) printw (" **T**"); //asterisk which lcn is opened
+
+      if (i == state->edacs_tuned_lcn && opts->p25_is_tuned == 1) printw (" **T**"); //asterisk which lcn is tuned
       printw ("\n");
     }
     if (state->carrier == 1)

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3531,28 +3531,28 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
       {
         if (state->ea_mode == 1) {
           // Voice call
-          if (call_matrix[i][4] & EDACS_IS_VOICE != 0)
+          if ((call_matrix[i][4] & EDACS_IS_VOICE) != 0)
           {
             // System all-call
-            if (call_matrix[i][4] & EDACS_IS_GROUP != 0)
+            if ((call_matrix[i][4] & EDACS_IS_GROUP) != 0)
               printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
             // I-Call
-            else if (call_matrix[i][4] & EDACS_IS_INDIVIDUAL != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_INDIVIDUAL) != 0)
               printw (" TGT [%8lld] SRC [%8lld] I-Call", call_matrix[i][2], call_matrix[i][3] );
             // System all-call
-            else if (call_matrix[i][4] & EDACS_IS_ALL_CALL != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_ALL_CALL) != 0)
               printw (" TGT [ SYSTEM ] SRC [%8lld] All-Call", call_matrix[i][3] );
             // Interconnect call
-            else if (call_matrix[i][4] & EDACS_IS_INTERCONNECT != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_INTERCONNECT) != 0)
               printw (" TGT [ SYSTEM ] SRC [%8lld] Interconnect", call_matrix[i][3] );
             // Unknown call
             else
               printw (" Unknown call type" );
 
             // Call flags
-            if (call_matrix[i][4] & EDACS_IS_DIGITAL == 0)   printw (" [Ana]");
-            else                                             printw (" [Dig]");
-            if (call_matrix[i][4] & EDACS_IS_EMERGENCY != 0) printw ("[EM]");
+            if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
+            else                                               printw (" [Dig]");
+            if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
           }
           else
             // Data call
@@ -3561,28 +3561,28 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
         else
         {
           // Voice call
-          if (call_matrix[i][4] & EDACS_IS_VOICE != 0)
+          if ((call_matrix[i][4] & EDACS_IS_VOICE) != 0)
           {
             // Group call
-            if (call_matrix[i][4] & EDACS_IS_GROUP != 0)
+            if ((call_matrix[i][4] & EDACS_IS_GROUP) != 0)
               printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
             // I-Call
-            else if (call_matrix[i][4] & EDACS_IS_INDIVIDUAL != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_INDIVIDUAL) != 0)
               printw (" TGT [%6lld][ UNIT ] SRC [%5lld] I-Call", call_matrix[i][2], call_matrix[i][3] );
             // System all-call
-            else if (call_matrix[i][4] & EDACS_IS_ALL_CALL != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_ALL_CALL) != 0)
               printw (" TGT [    SYSTEM    ] SRC [%5lld] All-Call", call_matrix[i][3] );
             // Interconnect call
-            else if (call_matrix[i][4] & EDACS_IS_INTERCONNECT != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_INTERCONNECT) != 0)
               printw (" TGT [    SYSTEM    ] SRC [%5lld] Interconnect", call_matrix[i][3] );
             // Unknown call
             else
               printw (" Unknown call type" );
 
             // Call flags
-            if (call_matrix[i][4] & EDACS_IS_DIGITAL == 0)   printw (" [Ana]");
-            else                                             printw (" [Dig]");
-            if (call_matrix[i][4] & EDACS_IS_EMERGENCY != 0) printw ("[EM]");
+            if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
+            else                                               printw (" [Dig]");
+            if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
           }
           else
             // Data call
@@ -3716,28 +3716,28 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           if (state->ea_mode == 1)
           {
             // Voice call
-            if (call_matrix[j][4] & EDACS_IS_VOICE != 0)
+            if ((call_matrix[j][4] & EDACS_IS_VOICE) != 0)
             {
               // Group call
-              if (call_matrix[j][4] & EDACS_IS_GROUP != 0)
+              if ((call_matrix[j][4] & EDACS_IS_GROUP) != 0)
                 printw ("Target [%8lld] Source [%8lld]", call_matrix[j][2], call_matrix[j][3]);
               // I-Call
-              else if (call_matrix[j][4] & EDACS_IS_INDIVIDUAL != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_INDIVIDUAL) != 0)
                 printw ("Target [%8lld] Source [%8lld] I-Call", call_matrix[j][2], call_matrix[j][3]);
               // System all-call
-              else if (call_matrix[j][4] & EDACS_IS_ALL_CALL != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_ALL_CALL) != 0)
                 printw ("Target [ SYSTEM ] Source [%8lld] All-Call", call_matrix[j][3]);
               // Interconnect
-              else if (call_matrix[j][4] & EDACS_IS_INTERCONNECT != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_INTERCONNECT) != 0)
                 printw ("Target [ SYSTEM ] Source [%8lld] Interconnect", call_matrix[j][3]);
               // Unknown call
               else
                 printw ("Unknown call type");
 
               // Call flags
-              if (call_matrix[i][4] & EDACS_IS_DIGITAL == 0)   printw (" [Ana]");
-              else                                             printw (" [Dig]");
-              if (call_matrix[i][4] & EDACS_IS_EMERGENCY != 0) printw ("[EM]");
+              if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
+              else                                               printw (" [Dig]");
+              if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
             }
             else
               // Data call
@@ -3746,32 +3746,32 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           else
           {
             // Voice call
-            if (call_matrix[j][4] & EDACS_IS_VOICE != 0)
+            if ((call_matrix[j][4] & EDACS_IS_VOICE) != 0)
             {
               // Compute 4:4:3 AFS for display purposes only
               int a  = (call_matrix[j][2] >> 7) & 0xF;
               int fs = call_matrix[j][2] & 0x7F;
 
               // Group call
-              if (call_matrix[j][4] & EDACS_IS_GROUP != 0)
+              if ((call_matrix[j][4] & EDACS_IS_GROUP) != 0)
                 printw ("Target [%6lld][%02d-%03d] Source [%5lld]", call_matrix[j][2], a, fs, call_matrix[j][3]);
               // I-Call
-              else if (call_matrix[j][4] & EDACS_IS_INDIVIDUAL != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_INDIVIDUAL) != 0)
                 printw ("Target [%6lld][ UNIT ] Source [%5lld] I-Call", call_matrix[j][2], call_matrix[j][3]);
               // System all-call
-              else if (call_matrix[j][4] & EDACS_IS_ALL_CALL != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_ALL_CALL) != 0)
                 printw ("Target [    SYSTEM    ] Source [%5lld] All-Call", call_matrix[j][3]);
               // Interconnect
-              else if (call_matrix[j][4] & EDACS_IS_INTERCONNECT != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_INTERCONNECT) != 0)
                 printw ("Target [    SYSTEM    ] Source [%5lld] Interconnect", call_matrix[j][3]);
               // Unknown call
               else
                 printw ("Unknown call type");
 
               // Call flags
-              if (call_matrix[i][4] & EDACS_IS_DIGITAL == 0)   printw (" [Ana]");
-              else                                             printw (" [Dig]");
-              if (call_matrix[i][4] & EDACS_IS_EMERGENCY != 0) printw ("[EM]");
+              if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
+              else                                               printw (" [Dig]");
+              if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
             }
             else
               // Data call

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3735,9 +3735,9 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
                 printw ("Unknown call type");
 
               // Call flags
-              if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
+              if ((call_matrix[j][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
               else                                               printw (" [Dig]");
-              if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
+              if ((call_matrix[j][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
             }
             else
               // Data call
@@ -3769,9 +3769,9 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
                 printw ("Unknown call type");
 
               // Call flags
-              if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
+              if ((call_matrix[j][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
               else                                               printw (" [Dig]");
-              if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
+              if ((call_matrix[j][4] & EDACS_IS_EMERGENCY) != 0) printw ("[EM]");
             }
             else
               // Data call

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1244,9 +1244,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int mt_c = (fr_1t & 0x300000000) >> 32;
           int lcn = (fr_1t & 0xF8000000) >> 27;
           int is_individual = (fr_1t & 0x4000000) >> 26;
-          int is_emergency = 0;
-          if (is_individual == 0)
-            is_emergency = (fr_1t & 0x2000000) >> 25;
+          int is_emergency = (is_individual == 0) ? (fr_1t & 0x2000000) >> 25 : 0;
           int group = (fr_1t & 0x7FF000) >> 12;
           int lid = (fr_1t & 0x3FFF000) >> 12;
           int source = (fr_4t & 0x3FFF000) >> 12; //Source only present in individual calls

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -542,6 +542,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
       unsigned char mt1 = (fr_1t & 0xF800000000) >> 35;
       unsigned char mt2 = (fr_1t & 0x780000000) >> 31;
 
+      state->edacs_vc_call_type = 0;
+
       //TODO: initialize where they are actually used
       unsigned long long int site_id = 0; //we probably could just make this an int as well as the state variables
       unsigned char lcn = 0;
@@ -1028,6 +1030,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
       unsigned char mt_a = (fr_1t & 0xE000000000) >> 37;
       unsigned char mt_b = (fr_1t & 0x1C00000000) >> 34;
       unsigned char mt_d = (fr_1t & 0x3E0000000) >> 29;
+
+      state->edacs_vc_call_type = 0;
 
       //Add raw payloads and MT-A/MT-B/MT-D for easy debug
       if (opts->payload == 1)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1682,7 +1682,69 @@ void edacs(dsd_opts * opts, dsd_state * state)
             if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
             fprintf (stderr, "%s", KNRM);
 
-            // TODO: Actually process the call
+            //LCNs >= 26 are reserved to indicate status (queued, busy, denied, etc)
+            if (lcn > state->edacs_lcn_count && lcn < 26)
+            {
+              state->edacs_lcn_count = lcn;
+            }
+            state->edacs_vc_lcn = lcn;
+
+            //Call info for state
+            state->lasttg = 0;
+            state->lastsrc = lid;
+
+                                 state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_ALL_CALL;
+            if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+
+            char mode[8]; //allow, block, digital enc
+            sprintf (mode, "%s", "");
+
+            //if we are using allow/whitelist mode, then write 'A' to mode for allow - always allow all-calls by default
+            if (opts->trunk_use_allow_list == 1) sprintf (mode, "%s", "A");
+
+            //NOTE: Restructured below so that analog and digital are handled the same, just that when
+            //its analog, it will now start edacs_analog which will while loop analog samples until
+            //signal level drops (RMS, or a dotting sequence is detected)
+
+            //this is working now with the new import setup
+            if ((opts->trunk_tune_group_calls == 1) && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block
+            {
+              if (lcn > 0 && lcn < 26 && state->edacs_cc_lcn != 0 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
+              {
+                //openwav file and do per call right here
+                if (opts->dmr_stereo_wav == 1 && (opts->use_rigctl == 1 || opts->audio_in_type == 3))
+                {
+                  sprintf (opts->wav_out_file, "./WAV/%s %s EDACS Site %lld SRC %05d All-Call.wav", getDateE(), timestr, state->edacs_site_id, state->lastsrc);
+                  if (is_digital == 0) openWavOutFile48k (opts, state); //analog at 48k
+                  else                 openWavOutFile (opts, state); //digital
+                }
+
+                if (opts->use_rigctl == 1)
+                {
+                  //only set bandwidth IF we have an original one to fall back to (experimental, but requires user to set the -B 12000 or -B 24000 value manually)
+                  if (opts->setmod_bw != 0)
+                  {
+                    if (is_digital == 0) SetModulation(opts->rigctl_sockfd, 7000); //narrower bandwidth, but has issues with dotting sequence
+                    else                 SetModulation(opts->rigctl_sockfd, opts->setmod_bw);
+                  }
+
+                  SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because our index starts at zero
+                  state->edacs_tuned_lcn = lcn;
+                  opts->p25_is_tuned = 1;
+                  if (is_digital == 0) edacs_analog(opts, state, target, lcn);
+                }
+
+                if (opts->audio_in_type == 3) //rtl dongle
+                {
+                  #ifdef USE_RTLSDR
+                  rtl_dev_tune (opts, state->trunk_lcn_freq[lcn-1]);
+                  state->edacs_tuned_lcn = lcn;
+                  opts->p25_is_tuned = 1;
+                  if (is_digital == 0) edacs_analog(opts, state, target, lcn);
+                  #endif
+                }
+              }
+            }
           }
           //Dynamic Regrouping (6.2.4.20)
           else if (mt_d == 0x10)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1244,7 +1244,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int mt_c = (fr_1t & 0x300000000) >> 32;
           int lcn = (fr_1t & 0xF8000000) >> 27;
           int is_individual = (fr_1t & 0x4000000) >> 26;
-          int is_emergency = is_individual ^ (fr_1t & 0x2000000) >> 25; //Emergency is exclusive with being an individual call
+          int is_emergency = 0;
+          if (is_individual == 0)
+            is_emergency = (fr_1t & 0x2000000) >> 25;
           int group = (fr_1t & 0x7FF000) >> 12;
           int lid = (fr_1t & 0x3FFF000) >> 12;
           int source = (fr_4t & 0x3FFF000) >> 12; //Source only present in individual calls

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -690,8 +690,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
         lcn = (fr_1t & 0x3E0000000) >> 29;
         int group  = (fr_1t & 0xFFFF000) >> 12;
         int source = (fr_4t & 0xFFFFF000) >> 12;
-        fprintf (stderr, "%s", KBLU);
-        fprintf (stderr, " Data Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, "%s", KGRN);
+        fprintf (stderr, " TDMA Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
       }
       //Data Group Grant Update
@@ -700,8 +700,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
         lcn = (fr_1t & 0x3E0000000) >> 29;
         int group  = (fr_1t & 0xFFFF000) >> 12;
         int source = (fr_4t & 0xFFFFF000) >> 12;
-        fprintf (stderr, "%s", KGRN);
-        fprintf (stderr, " TDMA Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, "%s", KBLU);
+        fprintf (stderr, " Data Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
       }
       //Voice Call Grant Update

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -726,9 +726,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int source = (fr_4t & 0xFFFFF000) >> 12;
 
         //Call info for state
+        if (lcn != 0)    state->edacs_vc_lcn = lcn;
                          state->lasttg = group; // 0 is a valid TG, it's the all-call for agency 0
         if (source != 0) state->lastsrc = source;
-        if (lcn != 0)    state->edacs_vc_lcn = lcn;
+
+        //Call type for state
                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
         if (is_digital == 1)   state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
         if (is_emergency == 1) state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
@@ -830,9 +832,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int source = (fr_4t & 0xFFFFF000) >> 12;
 
         //Call info for state
+        if (lcn != 0)    state->edacs_vc_lcn = lcn;
         if (target != 0) state->lasttg = target;
         if (source != 0) state->lastsrc = source;
-        if (lcn != 0)    state->edacs_vc_lcn = lcn;
+
+        //Call type for state
                              state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
         if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
@@ -907,9 +911,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
         }
 
         //Call info for state
-        if (source != 0) state->lastsrc = source;
         if (lcn != 0)    state->edacs_vc_lcn = lcn;
-                         state->edacs_vc_call_type = EDACS_IS_INDIVIDUAL;
+        if (source != 0) state->lastsrc = source;
+
+        //Call type for state
+        state->edacs_vc_call_type = EDACS_IS_INDIVIDUAL;
       }
       //System All-Call Grant Update
       else if (mt1 == 0x16)
@@ -927,9 +933,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int source = (fr_4t & 0xFFFFF000) >> 12;
 
         //Call info for state
+        if (lcn != 0)    state->edacs_vc_lcn = lcn;
                          state->lasttg = 0;
         if (source != 0) state->lastsrc = source;
-        if (lcn != 0)    state->edacs_vc_lcn = lcn;
+
+        //Call type for state
                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_ALL_CALL;
         if (is_digital == 1)   state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
@@ -1084,11 +1092,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
         {
           state->edacs_lcn_count = lcn;
         }
-        state->edacs_vc_lcn = lcn;
 
         //Call info for state
-        state->lasttg = group;
-        state->lastsrc = lid;
+        if (lcn != 0) state->edacs_vc_lcn = lcn;
+                      state->lasttg = group;
+                      state->lastsrc = lid;
+
+        //Call type for state
                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
         if (is_digital == 1)   state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
         if (is_emergency == 1) state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
@@ -1187,12 +1197,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
         {
           state->edacs_lcn_count = lcn;
         }
-        state->edacs_vc_lcn = lcn;
 
         //Call info for state
-        state->lasttg = target;
-        state->lastsrc = 0;
+        if (lcn != 0) state->edacs_vc_lcn = lcn;
+                      state->lasttg = target;
+                      state->lastsrc = 0;
 
+        //Call type for state
         if (is_individual_call == 0) state->edacs_vc_call_type = EDACS_IS_GROUP;
         else                         state->edacs_vc_call_type = EDACS_IS_INDIVIDUAL;
       }
@@ -1249,12 +1260,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
           {
             state->edacs_lcn_count = lcn;
           }
-          state->edacs_vc_lcn = lcn;
 
           //Call info for state
-          state->lasttg = 0;
-          state->lastsrc = target;
+          if (lcn != 0) state->edacs_vc_lcn = lcn;
+                        state->lasttg = 0;
+                        state->lastsrc = target;
 
+          //Call type for state
                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INTERCONNECT;
           if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
         }
@@ -1305,13 +1317,14 @@ void edacs(dsd_opts * opts, dsd_state * state)
           {
             state->edacs_lcn_count = lcn;
           }
-          state->edacs_vc_lcn = lcn;
 
           //Call info for state
-          state->lasttg = target;
-          //Alas, EDACS standard does not provide a source LID on channel updates - try to work around this on the display end instead
-          state->lastsrc = 0;
+          if (lcn != 0) state->edacs_vc_lcn = lcn;
+                        state->lasttg = target;
+                        //Alas, EDACS standard does not provide a source LID on channel updates - try to work around this on the display end instead
+                        state->lastsrc = 0;
 
+          //Call type for state
                                   state->edacs_vc_call_type  = EDACS_IS_VOICE;
           if (is_individual == 0) state->edacs_vc_call_type |= EDACS_IS_GROUP;
           else                    state->edacs_vc_call_type |= EDACS_IS_INDIVIDUAL;
@@ -1421,12 +1434,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
           {
             state->edacs_lcn_count = lcn;
           }
-          state->edacs_vc_lcn = lcn;
 
           //Call info for state
-          state->lasttg = target;
-          state->lastsrc = source;
+          if (lcn != 0) state->edacs_vc_lcn = lcn;
+                        state->lasttg = target;
+                        state->lastsrc = source;
 
+          //Call type for state
                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
           if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
@@ -1708,12 +1722,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
             {
               state->edacs_lcn_count = lcn;
             }
-            state->edacs_vc_lcn = lcn;
 
             //Call info for state
-            state->lasttg = 0;
-            state->lastsrc = lid;
+            if (lcn != 0) state->edacs_vc_lcn = lcn;
+                          state->lasttg = 0;
+                          state->lastsrc = lid;
 
+            //Call type for state
                                  state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_ALL_CALL;
             if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1175,6 +1175,20 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else                  fprintf (stderr, " <--");
         fprintf (stderr, " Port [%02d] LCN [%02d]%s", port, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
+
+        //LCNs >= 26 are reserved to indicate status (queued, busy, denied, etc)
+        if (lcn > state->edacs_lcn_count && lcn < 26)
+        {
+          state->edacs_lcn_count = lcn;
+        }
+        state->edacs_vc_lcn = lcn;
+
+        //Call info for state
+        state->lasttg = target;
+        state->lastsrc = 0;
+
+        if (is_individual_call == 0) state->edacs_vc_call_type  = EDACS_IS_GROUP;
+        else                         state->edacs_vc_call_type  = EDACS_IS_INDIVIDUAL;
       }
       //Login Acknowledge (6.2.4.4)
       else if (mt_a == 0x6)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1733,7 +1733,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
                   SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because our index starts at zero
                   state->edacs_tuned_lcn = lcn;
                   opts->p25_is_tuned = 1;
-                  if (is_digital == 0) edacs_analog(opts, state, target, lcn);
+                  if (is_digital == 0) edacs_analog(opts, state, 0, lcn);
                 }
 
                 if (opts->audio_in_type == 3) //rtl dongle
@@ -1742,7 +1742,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
                   rtl_dev_tune (opts, state->trunk_lcn_freq[lcn-1]);
                   state->edacs_tuned_lcn = lcn;
                   opts->p25_is_tuned = 1;
-                  if (is_digital == 0) edacs_analog(opts, state, target, lcn);
+                  if (is_digital == 0) edacs_analog(opts, state, 0, lcn);
                   #endif
                 }
               }

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1395,7 +1395,70 @@ void edacs(dsd_opts * opts, dsd_state * state)
           if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
           fprintf (stderr, "%s", KNRM);
 
-          // TODO: Actually process the call
+          //LCNs >= 26 are reserved to indicate status (queued, busy, denied, etc)
+          if (lcn > state->edacs_lcn_count && lcn < 26)
+          {
+            state->edacs_lcn_count = lcn;
+          }
+          state->edacs_vc_lcn = lcn;
+
+          //Call info for state
+          state->lasttg = target;
+          state->lastsrc = source;
+
+                               state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
+          if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+
+          char mode[8]; //allow, block, digital enc
+          sprintf (mode, "%s", "");
+
+          //if we are using allow/whitelist mode, then write 'B' to mode for block
+          //Individual calls always remain blocked if in allow/whitelist mode
+          if (opts->trunk_use_allow_list == 1) sprintf (mode, "%s", "B");
+
+          //NOTE: Restructured below so that analog and digital are handled the same, just that when
+          //its analog, it will now start edacs_analog which will while loop analog samples until
+          //signal level drops (RMS, or a dotting sequence is detected)
+
+          //this is working now with the new import setup
+          if ((opts->trunk_tune_private_calls == 1) && opts->p25_trunk == 1 && (strcmp(mode, "DE") != 0) && (strcmp(mode, "B") != 0) ) //DE is digital encrypted, B is block
+          {
+            if (lcn > 0 && lcn < 26 && state->edacs_cc_lcn != 0 && state->trunk_lcn_freq[lcn-1] != 0) //don't tune if zero (not loaded or otherwise)
+            {
+              //openwav file and do per call right here
+              if (opts->dmr_stereo_wav == 1 && (opts->use_rigctl == 1 || opts->audio_in_type == 3))
+              {
+                sprintf (opts->wav_out_file, "./WAV/%s %s EDACS Site %lld TGT %05d SRC %05d I-Call.wav", getDateE(), timestr, state->edacs_site_id, target, state->lastsrc);
+                if (is_digital == 0) openWavOutFile48k (opts, state); //analog at 48k
+                else                 openWavOutFile (opts, state); //digital
+              }
+
+              if (opts->use_rigctl == 1)
+              {
+                //only set bandwidth IF we have an original one to fall back to (experimental, but requires user to set the -B 12000 or -B 24000 value manually)
+                if (opts->setmod_bw != 0)
+                {
+                  if (is_digital == 0) SetModulation(opts->rigctl_sockfd, 7000); //narrower bandwidth, but has issues with dotting sequence
+                  else                 SetModulation(opts->rigctl_sockfd, opts->setmod_bw);
+                }
+
+                SetFreq(opts->rigctl_sockfd, state->trunk_lcn_freq[lcn-1]); //minus one because our index starts at zero
+                state->edacs_tuned_lcn = lcn;
+                opts->p25_is_tuned = 1;
+                if (is_digital == 0) edacs_analog(opts, state, target, lcn);
+              }
+
+              if (opts->audio_in_type == 3) //rtl dongle
+              {
+                #ifdef USE_RTLSDR
+                rtl_dev_tune (opts, state->trunk_lcn_freq[lcn-1]);
+                state->edacs_tuned_lcn = lcn;
+                opts->p25_is_tuned = 1;
+                if (is_digital == 0) edacs_analog(opts, state, target, lcn);
+                #endif
+              }
+            }
+          }
         }
         //Console Unkey / Drop (6.2.4.10)
         else if (mt_b == 0x6)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -729,7 +729,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
                          state->lasttg = group; // 0 is a valid TG, it's the all-call for agency 0
         if (source != 0) state->lastsrc = source;
         if (lcn != 0)    state->edacs_vc_lcn = lcn;
-                               state->edacs_vc_call_type  = EDACS_IS_GROUP;
+                               state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
         if (is_digital == 1)   state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
         if (is_emergency == 1) state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -900,6 +900,12 @@ void edacs(dsd_opts * opts, dsd_state * state)
         fprintf (stderr, " Channel Assignment (Unknown Data) :: Source [%08d] LCN [%02d]%s", source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
 
+        //LCNs greater than 26 are considered status values, "Busy, Queue, Deny, etc"
+        if (lcn > state->edacs_lcn_count && lcn < 26)
+        {
+          state->edacs_lcn_count = lcn;
+        }
+
         //Call info for state
         if (source != 0) state->lastsrc = source;
         if (lcn != 0)    state->edacs_vc_lcn = lcn;
@@ -1187,8 +1193,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
         state->lasttg = target;
         state->lastsrc = 0;
 
-        if (is_individual_call == 0) state->edacs_vc_call_type  = EDACS_IS_GROUP;
-        else                         state->edacs_vc_call_type  = EDACS_IS_INDIVIDUAL;
+        if (is_individual_call == 0) state->edacs_vc_call_type = EDACS_IS_GROUP;
+        else                         state->edacs_vc_call_type = EDACS_IS_INDIVIDUAL;
       }
       //Login Acknowledge (6.2.4.4)
       else if (mt_a == 0x6)


### PR DESCRIPTION
Rewrite a lot of the EDACS display code to deduplicate and to pass state to `ncurses` rather than using funny ID values to indicate whether a call is of a particular type.

Update various message parsing procedures for EDACS Standard messages based on data from live systems.

Tune individual and system all-calls on EDACS Standard.

*Disclaimer: this has not been tested yet, so please validate prior to merging.*