### PR TITLE
EDACS: fix AFS 4:4:3 display

### DIFF
--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3544,8 +3544,9 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
     for (i = 1; i <= state->edacs_lcn_count; i++)
     {
       // Compute 4:4:3 AFS for display purposes only
-      int a  = (call_matrix[i][2] >> 7) & 0xF;
-      int fs = call_matrix[i][2] & 0x7F;
+      int a = (call_matrix[i][2] >> 7) & 0xF;
+      int f = (call_matrix[i][2] >> 3) & 0xF;
+      int s = call_matrix[i][2] & 0x7;
       printw ("| - LCN [%02d][%010.06lf] MHz", i, (double)state->trunk_lcn_freq[i-1]/1000000);
 
       //print Control Channel on LCN line with the current Control Channel
@@ -3608,7 +3609,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           {
             // Group call
             if ((call_matrix[i][4] & EDACS_IS_GROUP) != 0)
-              printw (" TGT [%6lld][%02d-%03d] SRC [%5lld]", call_matrix[i][2], a, fs, call_matrix[i][3] );
+              printw (" TGT [%6lld][%02d-%02d%01d] SRC [%5lld]", call_matrix[i][2], a, f, s, call_matrix[i][3] );
             // I-Call
             else if ((call_matrix[i][4] & EDACS_IS_INDIVIDUAL) != 0)
               printw (" TGT [%6lld][ UNIT ] SRC [%5lld] I-Call", call_matrix[i][2], call_matrix[i][3] );
@@ -3792,12 +3793,13 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             if ((call_matrix[j][4] & EDACS_IS_VOICE) != 0)
             {
               // Compute 4:4:3 AFS for display purposes only
-              int a  = (call_matrix[j][2] >> 7) & 0xF;
-              int fs = call_matrix[j][2] & 0x7F;
+              int a = (call_matrix[j][2] >> 7) & 0xF;
+              int f = (call_matrix[j][2] >> 3) & 0xF;
+              int s = call_matrix[j][2] & 0x7;
 
               // Group call
               if ((call_matrix[j][4] & EDACS_IS_GROUP) != 0)
-                printw ("Target [%6lld][%02d-%03d] Source [%5lld]", call_matrix[j][2], a, fs, call_matrix[j][3]);
+                printw ("Target [%6lld][%02d-%02d%01d] Source [%5lld]", call_matrix[j][2], a, f, s, call_matrix[j][3]);
               // I-Call
               else if ((call_matrix[j][4] & EDACS_IS_INDIVIDUAL) != 0)
                 printw ("Target [%6lld][ UNIT ] Source [%5lld] I-Call", call_matrix[j][2], call_matrix[j][3]);

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -349,7 +349,10 @@ void edacs_analog(dsd_opts * opts, dsd_state * state, int afs, unsigned char lcn
     fprintf (stderr, " Analog RMS: %04ld SQL: %ld", rms, sql);
     if (state->ea_mode == 0)
     {
-      fprintf (stderr, " AFS [%03d] [%02d-%03d] LCN [%02d]", afs, afs >> 7, afs & 0x7F, lcn);
+      int a = (afs >> 7) & 0xF;
+      int f = (afs >> 3) & 0xF;
+      int s = afs & 0x7;
+      fprintf (stderr, " AFS [%03d] [%02d-%02d%01d] LCN [%02d]", afs, a, f, s, lcn);
     }
     else
     {


### PR DESCRIPTION
A-FS should be formatted as xx-yyz, per the standard used by scanner folks and RRDB. This was incorrectly formatting it as xx-yyy.