### PR TITLE
EDACS: implement voting error-correction algorithm, add new EA commands, refactor message parsing

### DIFF
--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -637,6 +637,20 @@ void edacs(dsd_opts * opts, dsd_state * state)
           else               fprintf (stderr, " Message Acknowledgement :: Status [%03d] Source [%08d]", status, source);
           fprintf (stderr, "%s", KNRM);
         }
+        //Unit Enable/Disable
+        else if (mt2 == 0x7)
+        {
+          int qualifier = (msg_2 & 0xC000000) >> 26;
+          int target    = (msg_2 & 0xFFFFF);
+          fprintf (stderr, "%s", KBLU);
+          fprintf (stderr, " Unit Enable/Disable ::");
+          if (qualifier == 0x0)      fprintf (stderr, " [Temporary Disable]");
+          else if (qualifier == 0x1) fprintf (stderr, " [Corrupt Personality]");
+          else if (qualifier == 0x2) fprintf (stderr, " [Revoke Logical ID]");
+          else                       fprintf (stderr, " [Re-enable Unit]");
+          fprintf (stderr, " Target [%05d]", target);
+          fprintf (stderr, "%s", KNRM);
+        }
         //Control Channel LCN
         else if (mt2 == 0x8)
         {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -632,23 +632,25 @@ void edacs(dsd_opts * opts, dsd_state * state)
         {
           int status = msg_1 & 0xFF;
           int source = msg_2 & 0xFFFFF;
+
           fprintf (stderr, "%s", KBLU);
           if (status == 248) fprintf (stderr, " Status Request :: Target [%08d]", source);
           else               fprintf (stderr, " Message Acknowledgement :: Status [%03d] Source [%08d]", status, source);
           fprintf (stderr, "%s", KNRM);
         }
-        //Unit Enable/Disable
+        //Unit Enable / Disable
         else if (mt2 == 0x7)
         {
           int qualifier = (msg_2 & 0xC000000) >> 26;
           int target    = (msg_2 & 0xFFFFF);
+
           fprintf (stderr, "%s", KBLU);
           fprintf (stderr, " Unit Enable/Disable ::");
           if (qualifier == 0x0)      fprintf (stderr, " [Temporary Disable]");
           else if (qualifier == 0x1) fprintf (stderr, " [Corrupt Personality]");
           else if (qualifier == 0x2) fprintf (stderr, " [Revoke Logical ID]");
           else                       fprintf (stderr, " [Re-enable Unit]");
-          fprintf (stderr, " Target [%05d]", target);
+          fprintf (stderr, " Target [%08d]", target);
           fprintf (stderr, "%s", KNRM);
         }
         //Control Channel LCN

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -687,16 +687,6 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, "%s", KNRM);
           state->edacs_site_id = site_id;
         }
-        //disabling kick command, data looks like its just FFFF, no actual values, can't verify accuracy
-        // else if (mt2 == 0xB) //KICK LISTING for EA?? Unverified, but probably observed in Unitrunker way back when.
-        // {
-        //   int kicked = (msg_2_ec & 0xFFFFF000) >> 12;
-        //   fprintf (stderr, " FR_1 [%010llX]", msg_1_ec);
-        //   fprintf (stderr, " FR_3 [%010llX]", fr_3);
-        //   fprintf (stderr, " FR_4 [%010llX]", msg_2_ec);
-        //   fprintf (stderr, " FR_6 [%010llX]", fr_6);
-        //   fprintf (stderr, " %08d REG/DEREG/AUTH?", kicked);
-        // }
         //Patch Groups
         else if (mt2 == 0xC)
         {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -701,6 +701,84 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, "%s", KNRM);
           state->edacs_site_id = site_id;
         }
+        //System Dynamic Regroup Plan Bitmap
+        else if (mt2 == 0xB)
+        {
+          int bank_1     = (msg_1 & 0x10000) >> 16;
+          int resident_1 = (msg_1 & 0xFF00) >> 8;
+          int active_1   = (msg_1 & 0xFF);
+          int bank_2     = (msg_2 & 0x10000) >> 16;
+          int resident_2 = (msg_2 & 0xFF00) >> 8;
+          int active_2   = (msg_2 & 0xFF);
+
+          fprintf (stderr, "%s", KYEL);
+          fprintf (stderr, " System Dynamic Regroup Plan Bitmap");
+
+          // Deduplicate some code with a for (foreach would have been great here)
+          for (int i = 0; i < 2; i++)
+          {
+            int bank;
+            int resident;
+            int active;
+
+            switch (i) {
+              case 0:
+                bank     = bank_1;
+                resident = resident_1;
+                active   = active_1;
+                break;
+              case 1:
+                bank     = bank_2;
+                resident = resident_2;
+                active   = active_2;
+                break;
+            }
+
+            fprintf (stderr, " :: Plan Bank [%1d] Resident [", bank);
+
+            int plan = bank * 8;
+            int first = 1;
+            while (resident != 0) {
+              if (resident & 0x1 == 1) {
+                if (first == 1)
+                {
+                  first = 0;
+                  fprintf (stderr, "%d", plan);
+                }
+                else
+                {
+                  fprintf (stderr, ", %d", plan);
+                }
+              }
+              resident >>= 1;
+              plan++;
+            }
+
+            fprintf (stderr, "] Active [");
+
+            plan = bank * 8;
+            first = 1;
+            while (active != 0) {
+              if (active & 0x1 == 1) {
+                if (first == 1)
+                {
+                  first = 0;
+                  fprintf (stderr, "%d", plan);
+                }
+                else
+                {
+                  fprintf (stderr, ", %d", plan);
+                }
+              }
+              active >>= 1;
+              plan++;
+            }
+
+            fprintf (stderr, "]");
+          }
+
+          fprintf (stderr, "%s", KNRM);
+        }
         //Patch Groups
         else if (mt2 == 0xC)
         {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -617,13 +617,14 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //Adjacent Sites
         else if (mt2 == 0x1)
         {
+          int adj_lcn  = (msg_1 & 0x1F000) >> 12;
+          int adj_site = (msg_1 & 0xFF);
+
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Adjacent Site");
-          if ( (msg_1 & 0xFF) > 0 )
+          if (adj_site > 0)
           {
-            int adj_l = (msg_1 & 0x1F000) >> 12;
-            int adj   = (msg_1 & 0xFF);
-            fprintf (stderr, " :: Site ID [%02X][%03d] on CC LCN [%02d]%s", adj, adj, adj_l, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: Site ID [%02X][%03d] on CC LCN [%02d]%s", adj_site, adj_site, adj_lcn, get_lcn_status_string(lcn));
           }
           fprintf (stderr, "%s", KNRM);
         }
@@ -698,6 +699,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else if (mt2 == 0xA)
         {
           site_id = (msg_1 & 0x1F) | ((msg_1 & 0x1F000) >> 7);
+
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Extended Addressing :: Site ID [%02llX][%03lld]", site_id, site_id);
           fprintf (stderr, "%s", KNRM);
@@ -787,6 +789,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int sourcep    = (msg_1 & 0xFFFF);
           int patch_site = (msg_2 & 0xFF00000) >> 20; //is site info valid, 0 for all sites? else patch only good on site listed?
           int targetp    = (msg_2 & 0xFFFF);
+
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Patch :: Site [%d] Source [%d] Target [%d] ", patch_site, sourcep, targetp);
           fprintf (stderr, "%s", KNRM);
@@ -819,6 +822,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         lcn        = (msg_1 & 0x3E0000) >> 17;
         int group  = (msg_1 & 0xFFFF);
         int source = (msg_2 & 0xFFFFF);
+
         fprintf (stderr, "%s", KGRN);
         fprintf (stderr, " TDMA Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
@@ -829,6 +833,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         lcn        = (msg_1 & 0x3E0000) >> 17;
         int group  = (msg_1 & 0xFFFF);
         int source = (msg_2 & 0xFFFFF);
+
         fprintf (stderr, "%s", KBLU);
         fprintf (stderr, " Data Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
@@ -1043,6 +1048,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
       {
         lcn        = (msg_2 & 0x1F00000) >> 20;
         int source = (msg_2 & 0xFFFFF);
+
         fprintf (stderr, "%s", KBLU);
         fprintf (stderr, " Channel Assignment (Unknown Data) :: Source [%08d] LCN [%02d]%s", source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -115,7 +115,7 @@ void edacs_analog(dsd_opts * opts, dsd_state * state, int afs, unsigned char lcn
   short analog1[960];
   short analog2[960];
   short analog3[960];
-  short sample = 0; 
+  short sample = 0;
 
   // #define DEBUG_ANALOG //enable to digitize analog if 'data' bursts heard
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -69,6 +69,27 @@ char* get_lcn_status_string(int lcn)
     return "";
 }
 
+//Bitwise vote-compare the three copies of a message received. Note that FR_2 is transmitted inverted.
+unsigned long long int edacs_vote_fr(unsigned long long int fr_1, unsigned long long int fr_2, unsigned long long int fr_3)
+{
+  fr_2 = (~fr_2) & 0xFFFFFFFFFF;
+
+  unsigned long long int msg_result = 0;
+  for (int i = 0; i < 40; i++)
+  {
+    int bit_1 = (fr_1 >> i) & 1;
+    int bit_2 = (fr_2 >> i) & 1;
+    int bit_3 = (fr_3 >> i) & 1;
+
+    //Vote: the value of the bit that we see the most is what we assume is correct
+    if (bit_1 + bit_2 + bit_3 > 1) {
+      msg_result |= (1ll << i);
+    }
+  }
+
+  return msg_result & 0xFFFFFFFFFF;
+}
+
 void openWavOutFile48k (dsd_opts * opts, dsd_state * state)
 {
   UNUSED(state);
@@ -509,6 +530,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
   }
 
+  //Old logic - take copy 1 of the first and second messages, then verify BCH on them.
+  // 
+  //TODO 2024-04-10: Keep this logic around for a bit to compare against new voting implementation.
   fr_1 = fr_1 & 0xFFFFFFFFFF;
   fr_4 = fr_4 & 0xFFFFFFFFFF;
 
@@ -522,9 +546,33 @@ void edacs(dsd_opts * opts, dsd_state * state)
   fr_1t = fr_1t & 0xFFFFFFFFFF;
   fr_4t = fr_4t & 0xFFFFFFFFFF;
 
-  if (fr_1 != fr_1t || fr_4 != fr_4t)
+  int old_bch_pass = (fr_1 == fr_1t) && (fr_4 == fr_4t);
+
+  //New logic - take our 3 copies of the first and second message and vote them to extract the "error-corrected" first
+  //and second message, then verify BCH on that.
+  unsigned long long int msg_1_ec = edacs_vote_fr(fr_1, fr_2, fr_3);
+  unsigned long long int msg_2_ec = edacs_vote_fr(fr_4, fr_5, fr_6);
+
+  unsigned long long int msg_1_ec_m = msg_1_ec >> 12;
+  unsigned long long int msg_2_ec_m = msg_2_ec >> 12;
+
+  //take our message and create a new crc for it, if it matches the old crc, then we have a good frame
+  unsigned long long int msg_1_ec_t = edacs_bch(msg_1_ec_m) & 0xFFFFFFFFFF;
+  unsigned long long int msg_2_ec_t = edacs_bch(msg_2_ec_m) & 0xFFFFFFFFFF;
+
+  int bch_pass = (msg_1_ec == msg_1_ec_t) && (msg_2_ec == msg_2_ec_t);
+
+  if (!bch_pass && !old_bch_pass)
   {
     fprintf (stderr, " BCH FAIL ");
+  }
+  else if (bch_pass && !old_bch_pass)
+  {
+    fprintf (stderr, " BCH FAIL (old logic only) ");
+  }
+  else if (!bch_pass && old_bch_pass)
+  {
+    fprintf (stderr, " BCH FAIL (new logic only)");
   }
   else //BCH Pass, continue from here.
   {

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -657,9 +657,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //Control Channel LCN
         else if (mt2 == 0x8)
         {
+          int system = msg_1 & 0xFFFF;
+          int lcn    = msg_2 & 0x1F;
+
           fprintf (stderr, "%s", KYEL);
-          fprintf (stderr, " Control Channel");
-          int lcn = msg_2 & 0x1F;
+          fprintf (stderr, " System Information");
           if (lcn != 0)
           {
             state->edacs_cc_lcn = lcn;
@@ -667,7 +669,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             {
               state->edacs_lcn_count = state->edacs_cc_lcn;
             }
-            fprintf (stderr, " :: LCN [%d]%s", state->edacs_cc_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: System ID [%04X] Control Channel LCN [%d]%s", system, state->edacs_cc_lcn, get_lcn_status_string(lcn));
 
             //check for control channel lcn frequency if not provided in channel map or in the lcn list
             if (state->trunk_lcn_freq[state->edacs_cc_lcn-1] == 0)
@@ -698,10 +700,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //Site ID
         else if (mt2 == 0xA)
         {
-          site_id = (msg_1 & 0x1F) | ((msg_1 & 0x1F000) >> 7);
+          site_id  = ((msg_1 & 0x7000) >> 7) | (msg_1 & 0x1F);
+          int area = (msg_1 & 0xFE0) >> 5;
 
           fprintf (stderr, "%s", KYEL);
-          fprintf (stderr, " Extended Addressing :: Site ID [%02llX][%03lld]", site_id, site_id);
+          fprintf (stderr, " Extended Addressing :: Site ID [%02llX][%03lld] Area [%02X][%03d]", site_id, site_id, area, area);
           fprintf (stderr, "%s", KNRM);
           state->edacs_site_id = site_id;
         }

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -791,7 +791,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int targetp    = (msg_2 & 0xFFFF);
 
           fprintf (stderr, "%s", KYEL);
-          fprintf (stderr, " Patch :: Site [%02X][%03d] Source [%d] Target [%d] ", patch_site, patch_site, sourcep, targetp);
+          fprintf (stderr, " Patch :: Site [%02X][%03d] Source [%05d] Target [%05d]", patch_site, patch_site, sourcep, targetp);
           fprintf (stderr, "%s", KNRM);
         }
         //Serial Number Request (not seen in the wild, see US patent 20030190923, Figure 2b)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -617,13 +617,14 @@ void edacs(dsd_opts * opts, dsd_state * state)
         //Adjacent Sites
         else if (mt2 == 0x1)
         {
+          int adj_lcn  = (msg_1 & 0x1F000) >> 12;
+          int adj_site = (msg_1 & 0xFF);
+
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Adjacent Site");
-          if ( (msg_1 & 0xFF) > 0 )
+          if (adj_site > 0)
           {
-            int adj_l = (msg_1 & 0x1F000) >> 12;
-            int adj   = (msg_1 & 0xFF);
-            fprintf (stderr, " :: Site ID [%02X][%03d] on CC LCN [%02d]%s", adj, adj, adj_l, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: Site ID [%02X][%03d] on CC LCN [%02d]%s", adj_site, adj_site, adj_lcn, get_lcn_status_string(lcn));
           }
           fprintf (stderr, "%s", KNRM);
         }
@@ -698,6 +699,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else if (mt2 == 0xA)
         {
           site_id = (msg_1 & 0x1F) | ((msg_1 & 0x1F000) >> 7);
+
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Extended Addressing :: Site ID [%02llX][%03lld]", site_id, site_id);
           fprintf (stderr, "%s", KNRM);
@@ -787,8 +789,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int sourcep    = (msg_1 & 0xFFFF);
           int patch_site = (msg_2 & 0xFF00000) >> 20; //is site info valid, 0 for all sites? else patch only good on site listed?
           int targetp    = (msg_2 & 0xFFFF);
+
           fprintf (stderr, "%s", KYEL);
-          fprintf (stderr, " Patch :: Site [%d] Source [%d] Target [%d] ", patch_site, sourcep, targetp);
+          fprintf (stderr, " Patch :: Site [%02X][%03d] Source [%d] Target [%d] ", patch_site, patch_site, sourcep, targetp);
           fprintf (stderr, "%s", KNRM);
         }
         //Serial Number Request (not seen in the wild, see US patent 20030190923, Figure 2b)
@@ -819,6 +822,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         lcn        = (msg_1 & 0x3E0000) >> 17;
         int group  = (msg_1 & 0xFFFF);
         int source = (msg_2 & 0xFFFFF);
+
         fprintf (stderr, "%s", KGRN);
         fprintf (stderr, " TDMA Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
@@ -829,6 +833,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         lcn        = (msg_1 & 0x3E0000) >> 17;
         int group  = (msg_1 & 0xFFFF);
         int source = (msg_2 & 0xFFFFF);
+
         fprintf (stderr, "%s", KBLU);
         fprintf (stderr, " Data Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);
@@ -1043,6 +1048,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
       {
         lcn        = (msg_2 & 0x1F00000) >> 20;
         int source = (msg_2 & 0xFFFFF);
+
         fprintf (stderr, "%s", KBLU);
         fprintf (stderr, " Channel Assignment (Unknown Data) :: Source [%08d] LCN [%02d]%s", source, lcn, get_lcn_status_string(lcn));
         fprintf (stderr, "%s", KNRM);


### PR DESCRIPTION
## Implement voting error-correction algorithm

EDACS CC messages are specified to be sent three times: normal polarity, bitwise inverted, and normal again. This means the `FR_1`/`FR_2`/`FR_3` and `FR_4`/`FR_5`/`FR_6` messages contain 3x redundant data, as a form of "error correction". To get a benefit from this, we need to compare the three and choose the correct values based on all three copies of the message.

The proper procedure for doing this is to do a bitwise voting comparison - whichever value of a bit is present in more copies of the message, is the value it should be.

Implement this and replace the current "yolo, just take the first one and see if BCH matches" logic.

## Add new EA commands

Add two new EA commands and test them on previous SLERS and current MBTA data:

- Unit Enable/Disable ("kick")
- System Dynamic Regroup Plan Bitmap

## Refactor message parsing

Currently we parse the CC messages in their raw form, including both the 28-bit data and the 12-bit BCH. This is somewhere between annoying at best and confusing at worst - it's easy to incorrectly do the math on shifting out the BCH while also shifting to get a particular field in the message.

Refactor the parsing to use just the 28-bit data message.