### PR TITLE
EDACS: Test Call improvements

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -770,7 +770,7 @@ typedef struct
   #define EDACS_IS_INDIVIDUAL   0x10
   #define EDACS_IS_ALL_CALL     0x20
   #define EDACS_IS_INTERCONNECT 0x40
-  #define EDACS_IS_TESTCALL     0x100
+  #define EDACS_IS_TEST_CALL    0x80
 
   //trunking group and lcn freq list
   long int trunk_lcn_freq[26]; //max number on an EDACS system, should be enough on DMR too hopefully

--- a/include/dsd.h
+++ b/include/dsd.h
@@ -763,14 +763,16 @@ typedef struct
   int edacs_s_mask;  //Calculated Mask for S Bits
 
   //flags for EDACS call type
-  #define EDACS_IS_VOICE        0x01
-  #define EDACS_IS_DIGITAL      0x02
-  #define EDACS_IS_EMERGENCY    0x04
-  #define EDACS_IS_GROUP        0x08
-  #define EDACS_IS_INDIVIDUAL   0x10
-  #define EDACS_IS_ALL_CALL     0x20
-  #define EDACS_IS_INTERCONNECT 0x40
-  #define EDACS_IS_TEST_CALL    0x80
+  #define EDACS_IS_VOICE         0x01
+  #define EDACS_IS_DIGITAL       0x02
+  #define EDACS_IS_EMERGENCY     0x04
+  #define EDACS_IS_GROUP         0x08
+  #define EDACS_IS_INDIVIDUAL    0x10
+  #define EDACS_IS_ALL_CALL      0x20
+  #define EDACS_IS_INTERCONNECT  0x40
+  #define EDACS_IS_TEST_CALL     0x80
+  #define EDACS_IS_AGENCY_CALL  0x100
+  #define EDACS_IS_FLEET_CALL   0x200
 
   //trunking group and lcn freq list
   long int trunk_lcn_freq[26]; //max number on an EDACS system, should be enough on DMR too hopefully

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3608,7 +3608,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           // Voice call
           if ((call_matrix[i][4] & EDACS_IS_VOICE) != 0)
           {
-            // System all-call
+            // Group call
             if ((call_matrix[i][4] & EDACS_IS_GROUP) != 0)
               printw (" TGT [%8lld] SRC [%8lld]", call_matrix[i][2], call_matrix[i][3] );
             // I-Call

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3665,6 +3665,8 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0) {}
             else if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
             else                                                    printw (" [Dig]");
+            if ((call_matrix[i][4] & EDACS_IS_AGENCY_CALL) != 0)    printw ("[A]");
+            if ((call_matrix[i][4] & EDACS_IS_FLEET_CALL) != 0)     printw ("[F]");
             if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");
           }
           else
@@ -3860,9 +3862,11 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
                 printw ("Unknown call type");
 
               // Call flags
-              if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0) {}
+              if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0)      {}
               else if ((call_matrix[j][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
               else                                                    printw (" [Dig]");
+              if ((call_matrix[j][4] & EDACS_IS_AGENCY_CALL) != 0)    printw ("[A]");
+              if ((call_matrix[j][4] & EDACS_IS_FLEET_CALL) != 0)     printw ("[F]");
               if ((call_matrix[j][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");
             }
             else

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3671,7 +3671,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
           }
           else
             // Data call
-            printw (" TGT [     DATA     ] SRC [%8lld] Data", call_matrix[i][3] );
+            printw (" TGT [     DATA     ] SRC [%5lld] Data", call_matrix[i][3] );
         }
         for (int k = 0; k < state->group_tally; k++)
         {

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3853,14 +3853,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               else if ((call_matrix[j][4] & EDACS_IS_INTERCONNECT) != 0)
                 printw ("Target [    SYSTEM    ] Source [%5lld] Interconnect", call_matrix[j][3]);
               // Test call
-              else if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0)
                 printw (" TEST CALL");
               // Unknown call
               else
                 printw ("Unknown call type");
 
               // Call flags
-              if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0) {}
+              if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0) {}
               else if ((call_matrix[j][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
               else                                                    printw (" [Dig]");
               if ((call_matrix[j][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3621,14 +3621,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             else if ((call_matrix[i][4] & EDACS_IS_INTERCONNECT) != 0)
               printw (" TGT [ SYSTEM ] SRC [%8lld] Interconnect", call_matrix[i][3] );
             // Test call
-            else if ((call_matrix[i][4] & EDACS_IS_TESTCALL) != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0)
               printw (" TEST CALL");
             // Unknown call
             else
               printw (" Unknown call type" );
 
             // Call flags
-            if ((call_matrix[i][4] & EDACS_IS_TESTCALL) != 0) {}
+            if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0) {}
             else if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
             else                                                    printw (" [Dig]");
             if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");
@@ -3655,14 +3655,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
             else if ((call_matrix[i][4] & EDACS_IS_INTERCONNECT) != 0)
               printw (" TGT [    SYSTEM    ] SRC [%5lld] Interconnect", call_matrix[i][3] );
             // Test call
-            else if ((call_matrix[i][4] & EDACS_IS_TESTCALL) != 0)
+            else if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0)
               printw (" TEST CALL");
             // Unknown call
             else
               printw (" Unknown call type" );
 
             // Call flags
-            if ((call_matrix[i][4] & EDACS_IS_TESTCALL) != 0) {}
+            if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0) {}
             else if ((call_matrix[i][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
             else                                                    printw (" [Dig]");
             if ((call_matrix[i][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");
@@ -3814,14 +3814,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               else if ((call_matrix[j][4] & EDACS_IS_INTERCONNECT) != 0)
                 printw ("Target [ SYSTEM ] Source [%8lld] Interconnect", call_matrix[j][3]);
               // Test call
-              else if ((call_matrix[j][4] & EDACS_IS_TESTCALL) != 0)
+              else if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0)
                 printw ("TEST CALL");
               // Unknown call
               else
                 printw ("Unknown call type");
 
               // Call flags
-              if ((call_matrix[j][4] & EDACS_IS_TESTCALL) != 0) {}
+              if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0) {}
               else if ((call_matrix[j][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
               else                                                    printw (" [Dig]");
               if ((call_matrix[j][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");
@@ -3853,14 +3853,14 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               else if ((call_matrix[j][4] & EDACS_IS_INTERCONNECT) != 0)
                 printw ("Target [    SYSTEM    ] Source [%5lld] Interconnect", call_matrix[j][3]);
               // Test call
-              else if ((call_matrix[i][4] & EDACS_IS_TESTCALL) != 0)
+              else if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0)
                 printw (" TEST CALL");
               // Unknown call
               else
                 printw ("Unknown call type");
 
               // Call flags
-              if ((call_matrix[i][4] & EDACS_IS_TESTCALL) != 0) {}
+              if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0) {}
               else if ((call_matrix[j][4] & EDACS_IS_DIGITAL) == 0)   printw (" [Ana]");
               else                                                    printw (" [Dig]");
               if ((call_matrix[j][4] & EDACS_IS_EMERGENCY) != 0)      printw ("[EM]");

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3854,7 +3854,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
                 printw ("Target [    SYSTEM    ] Source [%5lld] Interconnect", call_matrix[j][3]);
               // Test call
               else if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0)
-                printw ("Target [    SYSTEM    ] Source [ SYS ] Test Call", call_matrix[j][3]);
+                printw ("Target [    SYSTEM    ] Source [ SYS ] Test Call");
               // Unknown call
               else
                 printw ("Unknown call type");

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -951,7 +951,7 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
 
           }
 
-          
+
 
           TCP_END: ; //do nothing
 

--- a/src/dsd_ncurses.c
+++ b/src/dsd_ncurses.c
@@ -3622,7 +3622,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               printw (" TGT [ SYSTEM ] SRC [%8lld] Interconnect", call_matrix[i][3] );
             // Test call
             else if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0)
-              printw (" TEST CALL");
+              printw (" TGT [ SYSTEM ] SRC [ SYSTEM ] Test Call");
             // Unknown call
             else
               printw (" Unknown call type" );
@@ -3656,7 +3656,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
               printw (" TGT [    SYSTEM    ] SRC [%5lld] Interconnect", call_matrix[i][3] );
             // Test call
             else if ((call_matrix[i][4] & EDACS_IS_TEST_CALL) != 0)
-              printw (" TEST CALL");
+              printw (" TGT [    SYSTEM    ] SRC [ SYS ] Test Call");
             // Unknown call
             else
               printw (" Unknown call type" );
@@ -3815,7 +3815,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
                 printw ("Target [ SYSTEM ] Source [%8lld] Interconnect", call_matrix[j][3]);
               // Test call
               else if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0)
-                printw ("TEST CALL");
+                printw ("Target [ SYSTEM ] Source [ SYSTEM ] Test Call");
               // Unknown call
               else
                 printw ("Unknown call type");
@@ -3854,7 +3854,7 @@ ncursesPrinter (dsd_opts * opts, dsd_state * state)
                 printw ("Target [    SYSTEM    ] Source [%5lld] Interconnect", call_matrix[j][3]);
               // Test call
               else if ((call_matrix[j][4] & EDACS_IS_TEST_CALL) != 0)
-                printw (" TEST CALL");
+                printw ("Target [    SYSTEM    ] Source [ SYS ] Test Call", call_matrix[j][3]);
               // Unknown call
               else
                 printw ("Unknown call type");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -625,7 +625,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           //and overwrite current values in the matrix
           state->lasttg  = 999999999;
           state->lastsrc = 999999999;
-          state->edacs_vc_call_type = 0x101; //manually set to 0x101 to trigger voice call in ncurses, but no other flags
+          state->edacs_vc_call_type = EDACS_IS_TEST_CALL | EDACS_IS_VOICE; //manually set to trigger voice call in ncurses, but no other flags
         }
         //Adjacent Sites
         else if (mt2 == 0x1)
@@ -1022,7 +1022,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           //and overwrite current values in the matrix
           state->lasttg  = 999999999;
           state->lastsrc = 999999999;
-          state->edacs_vc_call_type = 0x101; //manually set to 0x101 to trigger voice call in ncurses, but no other flags
+          state->edacs_vc_call_type = EDACS_IS_TEST_CALL | EDACS_IS_VOICE; //manually set to trigger voice call in ncurses, but no other flags
           lcn = 0; //set to zero here, because this is not an actual call, so don't tune to it
         }
         else

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -821,9 +821,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int target  = (msg_2 & 0xFFFFF);         //target group or individual ID (20-bit) to include in supergroup
 
           fprintf (stderr, "%s", KWHT); //just make it stick out for now
-          fprintf (stderr, " System Dynamic Regroup :: SSN: %03d; SGID: %05d; Target: %07d;", ssn, sgid, target);
-          if (unk1) fprintf (stderr, " UNK1: %X;", unk1); //this value seems to always be zero
-          if (unk2) fprintf (stderr, " UNK2: %X;", unk2); //this value seems to always be zero
+          fprintf (stderr, " System Dynamic Regroup :: SSN [%03d] SGID[%05d] Target [%07d]", ssn, sgid, target);
+          if (unk1) fprintf (stderr, " UNK1: [%X]", unk1); //this value seems to always be zero
+          if (unk2) fprintf (stderr, " UNK2: [%X]", unk2); //this value seems to always be zero
           fprintf (stderr, "%s", KNRM);
         }
         //Serial Number Request (not seen in the wild, see US patent 20030190923, Figure 2b)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -464,15 +464,15 @@ void edacs(dsd_opts * opts, dsd_state * state)
   if (state->edacs_a_bits == 8)  state->edacs_a_mask = 0xFF;
   if (state->edacs_a_bits == 9)  state->edacs_a_mask = 0x1FF;
 
-  if (state->edacs_f_bits == 1)  state->edacs_s_mask = 0x1;
-  if (state->edacs_f_bits == 2)  state->edacs_s_mask = 0x3;
-  if (state->edacs_f_bits == 3)  state->edacs_s_mask = 0x7;
-  if (state->edacs_f_bits == 4)  state->edacs_s_mask = 0xF;
-  if (state->edacs_f_bits == 5)  state->edacs_s_mask = 0x1F;
-  if (state->edacs_f_bits == 6)  state->edacs_s_mask = 0x3F;
-  if (state->edacs_f_bits == 7)  state->edacs_s_mask = 0x7F;
-  if (state->edacs_f_bits == 8)  state->edacs_s_mask = 0xFF;
-  if (state->edacs_f_bits == 9)  state->edacs_s_mask = 0x1FF;
+  if (state->edacs_f_bits == 1)  state->edacs_f_mask = 0x1;
+  if (state->edacs_f_bits == 2)  state->edacs_f_mask = 0x3;
+  if (state->edacs_f_bits == 3)  state->edacs_f_mask = 0x7;
+  if (state->edacs_f_bits == 4)  state->edacs_f_mask = 0xF;
+  if (state->edacs_f_bits == 5)  state->edacs_f_mask = 0x1F;
+  if (state->edacs_f_bits == 6)  state->edacs_f_mask = 0x3F;
+  if (state->edacs_f_bits == 7)  state->edacs_f_mask = 0x7F;
+  if (state->edacs_f_bits == 8)  state->edacs_f_mask = 0xFF;
+  if (state->edacs_f_bits == 9)  state->edacs_f_mask = 0x1FF;
 
   if (state->edacs_s_bits == 1)  state->edacs_s_mask = 0x1;
   if (state->edacs_s_bits == 2)  state->edacs_s_mask = 0x3;

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -571,7 +571,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
     // - KCYN - voice individual calls
     // - KMAG - voice other calls (interconnect, all-call, test call, etc)
     // - KBLU - subscriber data
-    // - KWHT - unknown/reserved
+    // - KWHT - unknown/reserved/special
 
     //Account for ESK, if any
     unsigned long long int fr_esk_mask = ((unsigned long long int)state->esk_mask) << 20;
@@ -820,7 +820,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int unk2    = (msg_2 & 0xF0000) >> 16;   //unknown 4 bit value preceeding 20-bit target value of patch
           int target  = (msg_2 & 0xFFFFF);         //target group or individual ID (20-bit) to include in supergroup
 
-          fprintf (stderr, "%s", KMAG); //just make it stick out for now
+          fprintf (stderr, "%s", KWHT); //just make it stick out for now
           fprintf (stderr, " System Dynamic Regroup :: SSN: %03d; SGID: %05d; Target: %07d;", ssn, sgid, target);
           if (unk1) fprintf (stderr, " UNK1: %X;", unk1); //this value seems to always be zero
           if (unk2) fprintf (stderr, " UNK2: %X;", unk2); //this value seems to always be zero

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -607,7 +607,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
       if (mt1 == 0x1F)
       {
 
-        //Initiate Test Call (finally captured in the wild, along with the "I-Call" with zero target and zero source)
+        //Initiate Test Call (finally captured in the wild on SLERS EA, along with the "I-Call" with target and source of 0)
         if (mt2 == 0x0)
         {
           // MSG_1             [F802180] MSG_2 [0000000] (MT1: 1F; MT2: 0)  Initiate Test Call

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -798,7 +798,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else if (mt2 == 0xC)
         {
           //Note: First 9 bits of msg_1 are the mt1 and mt2 bits
-          int unk1    = (msg_1 & 0x70000) >> 20;   //unknown 3 bit value preceeding the SGID
+          int unk1    = (msg_1 & 0x70000) >> 16;   //unknown 3 bit value preceeding the SGID
           int sgid    = (msg_1 & 0xFFFF);          //patched supergroup ID
 
           //Updated Observation: The 'SSN' value may not be unique in this instance, so may be an entirely different value
@@ -806,11 +806,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
           int ssn     = (msg_2 & 0xFF00000) >> 20; //this value seems to incrememnt based on SGID, so assigning 8-bit as the SSN
           int target  = (msg_2 &   0xFFFFF);      //target group or individual ID (20-bit) to include in supergroup
-          
+
           fprintf (stderr, "%s", KWHT);
           fprintf (stderr, " System Dynamic Regroup :: SGID [%05d] Target [%07d]", sgid, target);
-          if (unk1) fprintf (stderr, " UNK1 [%01X]", unk1); //this value seems to always be zero
-          if (ssn)  fprintf (stderr, " UNK2 [%02X]", ssn); //this may or may not be a unique value to each SGID
+          if (unk1) fprintf (stderr, " UNK1 [%01X]", unk1); //this value seems to always be 7 for an active patch, 0 for a termination of a patch
+          if (ssn)  fprintf (stderr, " UNK2 [%02X]", ssn); //this may or may not be a unique value to each SGID, is FE for termination of a patch
           fprintf (stderr, "%s", KNRM);
         }
         //Serial Number Request (not seen in the wild, see US patent 20030190923, Figure 2b)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -69,15 +69,15 @@ char* get_lcn_status_string(int lcn)
     return "";
 }
 
-int is_agency_call_group(int afs)
+int is_agency_call_group(int afs, dsd_state * state)
 {
   int fs_mask = state->edacs_s_mask | (state->edacs_f_mask << state->edacs_f_shift);
-  return (afs & fs_mask) == 0
+  return (afs & fs_mask) == 0;
 }
 
-int is_fleet_call_group(int afs)
+int is_fleet_call_group(int afs, dsd_state * state)
 {
-  return (afs & state->edacs_s_mask) == 0
+  return (afs & state->edacs_s_mask) == 0;
 }
 
 //Bitwise vote-compare the three copies of a message received. Note that fr_2 and fr_5 are transmitted inverted.
@@ -1316,11 +1316,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
                       state->lastsrc = lid;
 
         //Call type for state
-                                         state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
-        if (is_digital == 1)             state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
-        if (is_emergency == 1)           state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
-        if (is_agency_call_group(group)) state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
-        if (is_fleet_call_group(group))  state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
+                                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
+        if (is_digital == 1)                    state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+        if (is_emergency == 1)                  state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+        if (is_agency_call_group(group, state)) state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
+        if (is_fleet_call_group(group, state))  state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
 
         char mode[8]; //allow, block, digital enc
         sprintf (mode, "%s", "");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -821,7 +821,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int target  = (msg_2 & 0xFFFFF);         //target group or individual ID (20-bit) to include in supergroup
 
           fprintf (stderr, "%s", KWHT); //just make it stick out for now
-          fprintf (stderr, " System Dynamic Regroup :: SSN [%03d] SGID[%05d] Target [%07d]", ssn, sgid, target);
+          fprintf (stderr, " System Dynamic Regroup :: SSN [%03d] SGID [%05d] Target [%07d]", ssn, sgid, target);
           if (unk1) fprintf (stderr, " UNK1: [%X]", unk1); //this value seems to always be zero
           if (unk2) fprintf (stderr, " UNK2: [%X]", unk2); //this value seems to always be zero
           fprintf (stderr, "%s", KNRM);

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -569,7 +569,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
     // - KYEL - system data
     // - KGRN - voice group calls
     // - KCYN - voice individual calls
-    // - KMAG - voice other calls (interconnect, all-call, etc)
+    // - KMAG - voice other calls (interconnect, all-call, test call, etc)
     // - KBLU - subscriber data
     // - KWHT - unknown/reserved
 
@@ -1006,9 +1006,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
                              state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
         if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
-        fprintf (stderr, "%s", KCYN);
         if (target == 0 && source == 0)
         {
+          fprintf (stderr, "%s", KMAG);
           //this seems to be the continuation of the Initiate Test Call Command
           //normally, this appears as an "Analog I-Call", but with 0 tg and src,
           //its possible that those values could still be present, and that all
@@ -1025,6 +1025,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         }
         else
         {
+          fprintf (stderr, "%s", KCYN);
           if (is_digital == 0) fprintf (stderr, " Analog I-Call");
           else                 fprintf (stderr, " Digital I-Call");
           if (is_update == 0) fprintf (stderr, " Assignment");
@@ -1644,7 +1645,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
           if (target == 0 && source == 0)
           {
-            fprintf (stderr, "%s", KYEL);
+            fprintf (stderr, "%s", KMAG);
             fprintf (stderr, " Test Call Channel Assignment ::");
             fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -872,7 +872,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             fprintf (stderr, " Patch Delete;");
             if (unk3)
               fprintf (stderr, " UNK3: %01X;", unk3);
-            if (unk3)
+            if (unk4)
               fprintf (stderr, " UNK4: %02X;", unk4);
           }
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -836,8 +836,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
           //look at the 'zero' fields when on 'delete'
           //              MSG_1  [FE00045] MSG_2 [FE00045]
           //                      FF80000 (visualization aide)
-          int unk3     = (msg_1 & 0x7FF00) >> 12;
-          int unk4     = (msg_2 & 0x7FF00) >> 12;;
+          int unk3     = (msg_1 & 0x7FF00) >> 8;
+          int unk4     = (msg_2 & 0x7FF00) >> 8;
 
           //Ilya, please don't nit fix my logging format for these, it breaks grep when parsing a bunch of these all at once
           fprintf (stderr, "%s", KWHT);
@@ -846,15 +846,17 @@ void edacs(dsd_opts * opts, dsd_state * state)
           if (sgid != target)
           {
             //decode potential TGA values (assumming same as Harris P25)
-            if (tga & 4) fprintf (stderr, " One-Way"); //Simulselect
-            else         fprintf (stderr, " Two-Way"); //Patch
-            if (tga & 2) fprintf (stderr, " Group");
-            else         fprintf (stderr, " Radio"); //Individual
-                        fprintf (stderr, " Patch");
+            //decided to disable the info presented below since I cannot confirm this
+            // if (tga & 4) fprintf (stderr, " One-Way"); //Simulselect
+            // else         fprintf (stderr, " Two-Way"); //Patch
+            // if (tga & 2) fprintf (stderr, " Group");
+            // else         fprintf (stderr, " Radio"); //Individual
+                         fprintf (stderr, " Patch");
             if (tga & 1) fprintf (stderr, " Active;");
             else         fprintf (stderr, " Delete;");
 
-            fprintf (stderr, " TGA: %01X;", tga); //this value seems to always be 7 for an active patch, 0 for a termination of a patch (6 if assigned the unk2 value)
+            //switched from using the TGA nomenclature to a more generic OPTion since I think this value is still a form of option
+            fprintf (stderr, " OPT: %01X;", tga); //this value seems to always be 7 for an active patch, 0 for a termination of a patch (6 if assigned the unk2 value)
             if (unk1)
               fprintf (stderr, " UNK1: %01X;", unk1);
             if (unk2)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -467,36 +467,10 @@ void edacs(dsd_opts * opts, dsd_state * state)
   state->edacs_a_shift = state->edacs_f_bits + state->edacs_s_bits;
   state->edacs_f_shift = state->edacs_s_bits;
 
-  //calculate masks via overkill copy and paste
-  if (state->edacs_a_bits == 1)  state->edacs_a_mask = 0x1;
-  if (state->edacs_a_bits == 2)  state->edacs_a_mask = 0x3;
-  if (state->edacs_a_bits == 3)  state->edacs_a_mask = 0x7;
-  if (state->edacs_a_bits == 4)  state->edacs_a_mask = 0xF;
-  if (state->edacs_a_bits == 5)  state->edacs_a_mask = 0x1F;
-  if (state->edacs_a_bits == 6)  state->edacs_a_mask = 0x3F;
-  if (state->edacs_a_bits == 7)  state->edacs_a_mask = 0x7F;
-  if (state->edacs_a_bits == 8)  state->edacs_a_mask = 0xFF;
-  if (state->edacs_a_bits == 9)  state->edacs_a_mask = 0x1FF;
-
-  if (state->edacs_f_bits == 1)  state->edacs_f_mask = 0x1;
-  if (state->edacs_f_bits == 2)  state->edacs_f_mask = 0x3;
-  if (state->edacs_f_bits == 3)  state->edacs_f_mask = 0x7;
-  if (state->edacs_f_bits == 4)  state->edacs_f_mask = 0xF;
-  if (state->edacs_f_bits == 5)  state->edacs_f_mask = 0x1F;
-  if (state->edacs_f_bits == 6)  state->edacs_f_mask = 0x3F;
-  if (state->edacs_f_bits == 7)  state->edacs_f_mask = 0x7F;
-  if (state->edacs_f_bits == 8)  state->edacs_f_mask = 0xFF;
-  if (state->edacs_f_bits == 9)  state->edacs_f_mask = 0x1FF;
-
-  if (state->edacs_s_bits == 1)  state->edacs_s_mask = 0x1;
-  if (state->edacs_s_bits == 2)  state->edacs_s_mask = 0x3;
-  if (state->edacs_s_bits == 3)  state->edacs_s_mask = 0x7;
-  if (state->edacs_s_bits == 4)  state->edacs_s_mask = 0xF;
-  if (state->edacs_s_bits == 5)  state->edacs_s_mask = 0x1F;
-  if (state->edacs_s_bits == 6)  state->edacs_s_mask = 0x3F;
-  if (state->edacs_s_bits == 7)  state->edacs_s_mask = 0x7F;
-  if (state->edacs_s_bits == 8)  state->edacs_s_mask = 0xFF;
-  if (state->edacs_s_bits == 9)  state->edacs_s_mask = 0x1FF;
+  //calculate masks using bitwise math
+  state->edacs_a_mask = (1 << state->edacs_a_bits) - 1;
+  state->edacs_f_mask = (1 << state->edacs_f_bits) - 1;
+  state->edacs_s_mask = (1 << state->edacs_s_bits) - 1;
 
   char * timestr; //add timestr here, so we can assign it and also free it to prevent memory leak
   timestr = getTimeE();

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -77,6 +77,9 @@ int is_agency_call_group(int afs, dsd_state * state)
 
 int is_fleet_call_group(int afs, dsd_state * state)
 {
+  if (is_agency_call_group(afs, state))
+    return 0;
+
   return (afs & state->edacs_s_mask) == 0;
 }
 
@@ -1316,11 +1319,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
                       state->lastsrc = lid;
 
         //Call type for state
-                                                state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
-        if (is_digital == 1)                    state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
-        if (is_emergency == 1)                  state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
-        if (is_agency_call_group(group, state)) state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
-        if (is_fleet_call_group(group, state))  state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
+                                                    state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
+        if (is_digital == 1)                        state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+        if (is_emergency == 1)                      state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+        if (is_agency_call_group(group, state))     state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
+        else if (is_fleet_call_group(group, state)) state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
 
         char mode[8]; //allow, block, digital enc
         sprintf (mode, "%s", "");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -832,8 +832,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
           
           fprintf (stderr, "%s", KWHT);
           fprintf (stderr, " System Dynamic Regroup :: SGID [%05d] Target [%07d]", sgid, target);
-          if (unk1) fprintf (stderr, " UNK1: [%01X]", unk1); //this value seems to always be zero
-          if (ssn)  fprintf (stderr, " UNK2: [%02X]", ssn); //this may or may not be a unique value to each SGID
+          if (unk1) fprintf (stderr, " UNK1 [%01X]", unk1); //this value seems to always be zero
+          if (ssn)  fprintf (stderr, " UNK2 [%02X]", ssn); //this may or may not be a unique value to each SGID
           fprintf (stderr, "%s", KNRM);
         }
         //Serial Number Request (not seen in the wild, see US patent 20030190923, Figure 2b)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -53,7 +53,7 @@ char * getTimeE(void) //get pretty hhmmss timestamp
   return curr;
 }
 
-char* get_lcn_status_string(int lcn)
+char * getLcnStatusString(int lcn)
 {
   if (lcn == 26 || lcn == 27)
     return "[Reserved LCN Status]";
@@ -69,22 +69,22 @@ char* get_lcn_status_string(int lcn)
     return "";
 }
 
-int is_agency_call_group(int afs, dsd_state * state)
+int isAgencyCallGroup(int afs, dsd_state * state)
 {
   int fs_mask = state->edacs_s_mask | (state->edacs_f_mask << state->edacs_f_shift);
   return (afs & fs_mask) == 0;
 }
 
-int is_fleet_call_group(int afs, dsd_state * state)
+int isFleetCallGroup(int afs, dsd_state * state)
 {
-  if (is_agency_call_group(afs, state))
+  if (isAgencyCallGroup(afs, state))
     return 0;
 
   return (afs & state->edacs_s_mask) == 0;
 }
 
 //Bitwise vote-compare the three copies of a message received. Note that fr_2 and fr_5 are transmitted inverted.
-unsigned long long int edacs_vote_fr(unsigned long long int fr_1_4, unsigned long long int fr_2_5, unsigned long long int fr_3_6)
+unsigned long long int edacsVoteFr(unsigned long long int fr_1_4, unsigned long long int fr_2_5, unsigned long long int fr_3_6)
 {
   fr_2_5 = (~fr_2_5) & 0xFFFFFFFFFF;
 
@@ -516,8 +516,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
   }
 
   //Take our 3 copies of the first and second message and vote them to extract the two "error-corrected" messages
-  unsigned long long int msg_1_ec = edacs_vote_fr(fr_1, fr_2, fr_3);
-  unsigned long long int msg_2_ec = edacs_vote_fr(fr_4, fr_5, fr_6);
+  unsigned long long int msg_1_ec = edacsVoteFr(fr_1, fr_2, fr_3);
+  unsigned long long int msg_2_ec = edacsVoteFr(fr_4, fr_5, fr_6);
 
   //Get just the 28-bit message portion
   unsigned long long int msg_1_ec_m = msg_1_ec >> 12;
@@ -623,7 +623,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Adjacent Site");
           if (adj_site > 0)
-            fprintf (stderr, " :: Site ID [%02X][%03d] Index [%d] on CC LCN [%02d]%s", adj_site, adj_site, adj_idx, adj_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: Site ID [%02X][%03d] Index [%d] on CC LCN [%02d]%s", adj_site, adj_site, adj_idx, adj_lcn, getLcnStatusString(lcn));
           else fprintf (stderr, " :: Total Indexed [%d]", adj_idx); //if site value is 0, then this tells us the total number of adjacent sites
 
           if (adj_site == 0 && adj_idx == 0)      fprintf (stderr, " [Adjacency Table Reset]");
@@ -673,7 +673,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             {
               state->edacs_lcn_count = state->edacs_cc_lcn;
             }
-            fprintf (stderr, " :: System ID [%04X] CC LCN [%02d]%s", system, state->edacs_cc_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: System ID [%04X] CC LCN [%02d]%s", system, state->edacs_cc_lcn, getLcnStatusString(lcn));
 
             //check for control channel lcn frequency if not provided in channel map or in the lcn list
             if (state->trunk_lcn_freq[state->edacs_cc_lcn-1] == 0)
@@ -843,7 +843,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int source = (msg_2 & 0xFFFFF);
 
         fprintf (stderr, "%s", KGRN);
-        fprintf (stderr, " TDMA Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " TDMA Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, getLcnStatusString(lcn));
         fprintf (stderr, "%s", KNRM);
       }
       //Data Group Grant Update
@@ -854,7 +854,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int source = (msg_2 & 0xFFFFF);
 
         fprintf (stderr, "%s", KBLU);
-        fprintf (stderr, " Data Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " Data Group Call :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, getLcnStatusString(lcn));
         fprintf (stderr, "%s", KNRM);
       }
       //Voice Call Grant Update
@@ -893,7 +893,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else                 fprintf (stderr, " Digital Group Call");
         if (is_update == 0) fprintf (stderr, " Assignment");
         else                fprintf (stderr, " Update");
-        fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " :: Group [%05d] Source [%08d] LCN [%02d]%s", group, source, lcn, getLcnStatusString(lcn));
 
         //Trunking mode is correlated to (but not guaranteed to match) the type of call:
         // - emergency calls - usually message trunking
@@ -1001,7 +1001,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, " Test Call");
           if (is_update == 0) fprintf (stderr, " Assignment");
           else                fprintf (stderr, " Update");
-          fprintf (stderr, " :: LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
+          fprintf (stderr, " :: LCN [%02d]%s", lcn, getLcnStatusString(lcn));
           state->edacs_vc_lcn = lcn;
           //assign bogus values so that this will show up in ncurses terminal
           //and overwrite current values in the matrix
@@ -1017,7 +1017,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           if (is_update == 0) fprintf (stderr, " Assignment");
           else                fprintf (stderr, " Update");
 
-          fprintf (stderr, " :: Target [%08d] Source [%08d] LCN [%02d]%s", target, source, lcn, get_lcn_status_string(lcn));
+          fprintf (stderr, " :: Target [%08d] Source [%08d] LCN [%02d]%s", target, source, lcn, getLcnStatusString(lcn));
         }
 
         fprintf (stderr, "%s", KNRM);
@@ -1089,7 +1089,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         int source = (msg_2 & 0xFFFFF);
 
         fprintf (stderr, "%s", KBLU);
-        fprintf (stderr, " Channel Assignment (Unknown Data) :: Source [%08d] LCN [%02d]%s", source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " Channel Assignment (Unknown Data) :: Source [%08d] LCN [%02d]%s", source, lcn, getLcnStatusString(lcn));
         fprintf (stderr, "%s", KNRM);
 
         //LCNs greater than 26 are considered status values, "Busy, Queue, Deny, etc"
@@ -1135,7 +1135,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         if (is_update == 0) fprintf (stderr, " Assignment");
         else                fprintf (stderr, " Update");
 
-        fprintf (stderr, " :: Source [%08d] LCN [%02d]%s", source, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " :: Source [%08d] LCN [%02d]%s", source, lcn, getLcnStatusString(lcn));
         fprintf (stderr, "%s", KNRM);
 
         char mode[8]; //allow, block, digital enc
@@ -1272,7 +1272,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         fprintf (stderr, " Voice Group Channel Assignment ::");
         if (is_digital == 0) fprintf (stderr, " Analog");
         else                 fprintf (stderr, " Digital");
-        fprintf (stderr, " Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " Group [%04d] LID [%05d] LCN [%02d]%s", group, lid, lcn, getLcnStatusString(lcn));
         if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
         if (is_emergency == 1)
         {
@@ -1293,11 +1293,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
                       state->lastsrc = lid;
 
         //Call type for state
-                                                    state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
-        if (is_digital == 1)                        state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
-        if (is_emergency == 1)                      state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
-        if (is_agency_call_group(group, state))     state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
-        else if (is_fleet_call_group(group, state)) state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
+                                                 state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
+        if (is_digital == 1)                     state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+        if (is_emergency == 1)                   state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+        if (isAgencyCallGroup(group, state))     state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
+        else if (isFleetCallGroup(group, state)) state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
 
         char mode[8]; //allow, block, digital enc
         sprintf (mode, "%s", "");
@@ -1385,7 +1385,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         else                       fprintf (stderr, " Group [%04d]", target);
         if (is_from_lid == 1) fprintf (stderr, " -->");
         else                  fprintf (stderr, " <--");
-        fprintf (stderr, " Port [%02d] LCN [%02d]%s", port, lcn, get_lcn_status_string(lcn));
+        fprintf (stderr, " Port [%02d] LCN [%02d]%s", port, lcn, getLcnStatusString(lcn));
         fprintf (stderr, "%s", KNRM);
 
         //LCNs >= 26 are reserved to indicate status (queued, busy, denied, etc)
@@ -1448,7 +1448,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           else                 fprintf (stderr, " Digital");
           if (is_individual_id == 1) fprintf (stderr, " LID [%05d]", target);
           else                       fprintf (stderr, " Group [%04d]", target);
-          fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
+          fprintf (stderr, " LCN [%02d]%s", lcn, getLcnStatusString(lcn));
           fprintf (stderr, "%s", KNRM);
 
           //LCNs >= 26 are reserved to indicate status (queued, busy, denied, etc)
@@ -1508,7 +1508,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           else                 fprintf (stderr, " Digital");
           if (is_individual == 0)     fprintf (stderr, " Group [%04d]", target);
           else if (is_test_call == 0) fprintf (stderr, " Callee [%05d] Caller [%05d]", target, source);
-          fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
+          fprintf (stderr, " LCN [%02d]%s", lcn, getLcnStatusString(lcn));
           if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
           if (is_emergency == 1)
           {
@@ -1530,13 +1530,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
                         state->lastsrc = 0;
 
           //Call type for state
-                                                      state->edacs_vc_call_type  = EDACS_IS_VOICE;
-          if (is_individual == 0)                     state->edacs_vc_call_type |= EDACS_IS_GROUP;
-          else                                        state->edacs_vc_call_type |= EDACS_IS_INDIVIDUAL;
-          if (is_digital == 1)                        state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
-          if (is_emergency == 1)                      state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
-          if (is_agency_call_group(group, state))     state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
-          else if (is_fleet_call_group(group, state)) state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
+                                                   state->edacs_vc_call_type  = EDACS_IS_VOICE;
+          if (is_individual == 0)                  state->edacs_vc_call_type |= EDACS_IS_GROUP;
+          else                                     state->edacs_vc_call_type |= EDACS_IS_INDIVIDUAL;
+          if (is_digital == 1)                     state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+          if (is_emergency == 1)                   state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+          if (isAgencyCallGroup(group, state))     state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
+          else if (isFleetCallGroup(group, state)) state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
 
           char mode[8]; //allow, block, digital enc
           sprintf (mode, "%s", "");
@@ -1637,7 +1637,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           {
             fprintf (stderr, "%s", KMAG);
             fprintf (stderr, " Test Call Channel Assignment ::");
-            fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " LCN [%02d]%s", lcn, getLcnStatusString(lcn));
 
             state->edacs_vc_lcn = lcn;
             //assign bogus values so that this will show up in ncurses terminal and overwrite current values in the matrix
@@ -1650,7 +1650,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             fprintf (stderr, " Voice Individual Channel Assignment ::");
             if (is_digital == 0) fprintf (stderr, " Analog");
             else                 fprintf (stderr, " Digital");
-            fprintf (stderr, " Callee [%05d] Caller [%05d] LCN [%02d]%s", target, source, lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " Callee [%05d] Caller [%05d] LCN [%02d]%s", target, source, lcn, getLcnStatusString(lcn));
             if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
           }
           fprintf (stderr, "%s", KNRM);
@@ -1733,7 +1733,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           fprintf (stderr, " Console ");
           if (is_drop == 0) fprintf (stderr, " Unkey");
           else              fprintf (stderr, " Drop");
-          fprintf (stderr, " :: LID [%05d] LCN [%02d]%s", lid, lcn, get_lcn_status_string(lcn));
+          fprintf (stderr, " :: LID [%05d] LCN [%02d]%s", lid, lcn, getLcnStatusString(lcn));
           fprintf (stderr, "%s", KNRM);
         }
         //Use MT-D
@@ -1757,7 +1757,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int adj_site_id    = (msg_1 & 0x1F0) >> 4;
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Adjacent Site Control Channel :: Site ID [%02X][%03d] Index [%1d] LCN [%02d]%s", adj_site_id, adj_site_id, adj_site_index, adj_cc_lcn, get_lcn_status_string(adj_cc_lcn));
+            fprintf (stderr, " Adjacent Site Control Channel :: Site ID [%02X][%03d] Index [%1d] LCN [%02d]%s", adj_site_id, adj_site_id, adj_site_index, adj_cc_lcn, getLcnStatusString(adj_cc_lcn));
             if (adj_site_id == 0 && adj_site_index == 0)      fprintf (stderr, " [Adjacency Table Reset]");
             else if (adj_site_id != 0 && adj_site_index == 0) fprintf (stderr, " [Priority System Definition]");
             else if (adj_site_id == 0 && adj_site_index != 0) fprintf (stderr, " [Adjacencies Table Length Definition]");
@@ -1838,7 +1838,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int group      = (msg_1 & 0x7FF);
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Assignment to Auxiliary CC :: Group [%04d] Aux CC LCN [%02d]%s", group, aux_cc_lcn, get_lcn_status_string(aux_cc_lcn));
+            fprintf (stderr, " Assignment to Auxiliary CC :: Group [%04d] Aux CC LCN [%02d]%s", group, aux_cc_lcn, getLcnStatusString(aux_cc_lcn));
             fprintf (stderr, "%s", KNRM);
           }
           //Initiate Test Call Command (6.2.4.16)
@@ -1877,7 +1877,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             int site_id      = (msg_1 & 0x1F);
 
             fprintf (stderr, "%s", KYEL);
-            fprintf (stderr, " Standard/Networked :: Site ID [%02X][%03d] Priority [%1d] CC LCN [%02d]%s", site_id, site_id, priority, cc_lcn, get_lcn_status_string(cc_lcn));
+            fprintf (stderr, " Standard/Networked :: Site ID [%02X][%03d] Priority [%1d] CC LCN [%02d]%s", site_id, site_id, priority, cc_lcn, getLcnStatusString(cc_lcn));
             if (is_failsoft == 1)
             {
               fprintf (stderr, "%s", KRED);
@@ -1946,7 +1946,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             fprintf (stderr, " ::");
             if (is_digital == 0) fprintf (stderr, " Analog");
             else                 fprintf (stderr, " Digital");
-            fprintf (stderr, " LID [%05d] LCN [%02d]%s", lid, lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " LID [%05d] LCN [%02d]%s", lid, lcn, getLcnStatusString(lcn));
             if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
             fprintf (stderr, "%s", KNRM);
 

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1632,12 +1632,27 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int target      = (msg_1 & 0x3FFF);
           int source      = (msg_2 & 0x3FFF);
 
-          fprintf (stderr, "%s", KCYN);
-          fprintf (stderr, " Individual Call Channel Assignment ::");
-          if (is_digital == 0) fprintf (stderr, " Analog");
-          else                 fprintf (stderr, " Digital");
-          fprintf (stderr, " Callee [%05d] Caller [%05d] LCN [%02d]%s", target, source, lcn, get_lcn_status_string(lcn));
-          if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
+          if (target == 0 && source == 0)
+          {
+            fprintf (stderr, "%s", KYEL);
+            fprintf (stderr, " Test Call Channel Assignment ::");
+            fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
+
+            state->edacs_vc_lcn = lcn;
+            //assign bogus values so that this will show up in ncurses terminal and overwrite current values in the matrix
+            state->lasttg  = 999999999;
+            state->lastsrc = 999999999;
+            state->edacs_vc_call_type = EDACS_IS_TEST_CALL | EDACS_IS_VOICE; //manually set to trigger voice call in ncurses, but no other flags
+            lcn = 0; //set to zero here, because this is not an actual call, so don't tune to it
+          }
+          else {
+            fprintf (stderr, "%s", KCYN);
+            fprintf (stderr, " Voice Individual Channel Assignment ::");
+            if (is_digital == 0) fprintf (stderr, " Analog");
+            else                 fprintf (stderr, " Digital");
+            fprintf (stderr, " Callee [%05d] Caller [%05d] LCN [%02d]%s", target, source, lcn, get_lcn_status_string(lcn));
+            if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
+          }
           fprintf (stderr, "%s", KNRM);
 
           //LCNs >= 26 are reserved to indicate status (queued, busy, denied, etc)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1530,11 +1530,13 @@ void edacs(dsd_opts * opts, dsd_state * state)
                         state->lastsrc = 0;
 
           //Call type for state
-                                  state->edacs_vc_call_type  = EDACS_IS_VOICE;
-          if (is_individual == 0) state->edacs_vc_call_type |= EDACS_IS_GROUP;
-          else                    state->edacs_vc_call_type |= EDACS_IS_INDIVIDUAL;
-          if (is_digital == 1)    state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
-          if (is_emergency == 1)  state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+                                                      state->edacs_vc_call_type  = EDACS_IS_VOICE;
+          if (is_individual == 0)                     state->edacs_vc_call_type |= EDACS_IS_GROUP;
+          else                                        state->edacs_vc_call_type |= EDACS_IS_INDIVIDUAL;
+          if (is_digital == 1)                        state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+          if (is_emergency == 1)                      state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+          if (is_agency_call_group(group, state))     state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
+          else if (is_fleet_call_group(group, state)) state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
 
           char mode[8]; //allow, block, digital enc
           sprintf (mode, "%s", "");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -69,6 +69,17 @@ char* get_lcn_status_string(int lcn)
     return "";
 }
 
+int is_agency_call_group(int afs)
+{
+  int fs_mask = state->edacs_s_mask | (state->edacs_f_mask << state->edacs_f_shift);
+  return (afs & fs_mask) == 0
+}
+
+int is_fleet_call_group(int afs)
+{
+  return (afs & state->edacs_s_mask) == 0
+}
+
 //Bitwise vote-compare the three copies of a message received. Note that fr_2 and fr_5 are transmitted inverted.
 unsigned long long int edacs_vote_fr(unsigned long long int fr_1_4, unsigned long long int fr_2_5, unsigned long long int fr_3_6)
 {
@@ -1305,9 +1316,11 @@ void edacs(dsd_opts * opts, dsd_state * state)
                       state->lastsrc = lid;
 
         //Call type for state
-                               state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
-        if (is_digital == 1)   state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
-        if (is_emergency == 1) state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+                                         state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_GROUP;
+        if (is_digital == 1)             state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+        if (is_emergency == 1)           state->edacs_vc_call_type |= EDACS_IS_EMERGENCY;
+        if (is_agency_call_group(group)) state->edacs_vc_call_type |= EDACS_IS_AGENCY_CALL;
+        if (is_fleet_call_group(group))  state->edacs_vc_call_type |= EDACS_IS_FLEET_CALL;
 
         char mode[8]; //allow, block, digital enc
         sprintf (mode, "%s", "");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -607,17 +607,15 @@ void edacs(dsd_opts * opts, dsd_state * state)
       if (mt1 == 0x1F)
       {
 
-        //Test Call (not seen in the wild, see US patent US7546135B2, Figure 2b)
-        //Finally Captured in the wild, along with the "I-Call" with zero target and zero source
+        //Initiate Test Call (finally captured in the wild, along with the "I-Call" with zero target and zero source)
         if (mt2 == 0x0)
         {
-
           // MSG_1             [F802180] MSG_2 [0000000] (MT1: 1F; MT2: 0)  Initiate Test Call
           int cc_lcn = (msg_1 & 0x3E000) >> 13; //shifted to allow this example to be CC LCN 1, as was reported at the time of capture
           int wc_lcn =   (msg_1 & 0xF80) >> 7;
 
           fprintf (stderr, "%s", KYEL);
-          fprintf (stderr, " Initiate Test Call :: CC LCN: %02d; WC LCN: %02d;", cc_lcn, wc_lcn);
+          fprintf (stderr, " Initiate Test Call :: CC LCN [%02d] WC LCN [%02d]", cc_lcn, wc_lcn);
           fprintf (stderr, "%s", KNRM);
 
           state->edacs_vc_lcn = wc_lcn;
@@ -633,7 +631,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int adj_lcn  = (msg_1 & 0x1F000) >> 12;
           int adj_idx  = (msg_1 & 0xF00) >> 8; //site 177 has 8 adj_sites, so this appears to be a 4-bit value
           int adj_site = (msg_1 & 0xFF);
-          
+
           fprintf (stderr, "%s", KYEL);
           fprintf (stderr, " Adjacent Site");
           if (adj_site > 0)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -2092,7 +2092,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
     //let users know they need to select an operational mode with the switches below
     else
     {
-      fprintf (stderr, " Detected: Use -fh, -fH, -fe, or -fE for std, esk, ea, or ea-esk;");
+      fprintf (stderr, " Detected EDACS: Use -fh, -fH, -fe, or -fE for std, esk, ea, or ea-esk to specify the type");
       fprintf (stderr, "\n");
       fprintf (stderr, " MSG_1 [%07llX]", msg_1);
       fprintf (stderr, " MSG_2 [%07llX]", msg_2);

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -1479,6 +1479,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         }
         //Channel Updates (6.2.4.7)
         //Source/caller being present in individual call channel updates reverse engineered from Montreal STM system
+        //Test calls reverse engineered from HartLink system
         else if (mt_b == 0x3)
         {
           int mt_c          = (msg_1 & 0x300000) >> 20;
@@ -1492,6 +1493,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
           //Abstract away to a target, and be sure to check whether it's an individual call later
           int target = (is_individual == 0) ? group : lid;
 
+          //Test calls are just individual calls with source and target of 0
+          int is_test_call = (target == 0 && source == 0);
+
           //Technically only MT-C 0x1 and 0x3 are defined in TSB 69.3 - using and extrapolating on legacy code
           int is_tx_trunk = (mt_c == 2 || mt_c == 3) ? 1 : 0;
           int is_digital = (mt_c == 1 || mt_c == 3) ? 1 : 0;
@@ -1501,15 +1505,20 @@ void edacs(dsd_opts * opts, dsd_state * state)
             fprintf (stderr, "%s", KGRN);
             fprintf (stderr, " Voice Group Channel Update ::");
           }
-          else
+          else if (is_test_call == 0)
           {
             fprintf (stderr, "%s", KCYN);
             fprintf (stderr, " Voice Individual Channel Update ::");
           }
+          else
+          {
+            fprintf (stderr, "%s", KYEL);
+            fprintf (stderr, " Voice Test Channel Update ::");
+          }
           if (is_digital == 0) fprintf (stderr, " Analog");
           else                 fprintf (stderr, " Digital");
-          if (is_individual == 0) fprintf (stderr, " Group [%04d]", target);
-          else                    fprintf (stderr, " Callee [%05d] Caller [%05d]", target, source);
+          if (is_individual == 0)     fprintf (stderr, " Group [%04d]", target);
+          else if (is_test_call == 0) fprintf (stderr, " Callee [%05d] Caller [%05d]", target, source);
           fprintf (stderr, " LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
           if (is_tx_trunk == 0) fprintf (stderr, " [Message Trunking]");
           if (is_emergency == 1)
@@ -1624,6 +1633,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
         }
         //Individual Call Channel Assignment (6.2.4.9)
         //Analog and digital flag reverse engineered from Montreal STM system
+        //Test calls reverse engineered from HartLink system
         else if (mt_b == 0x5)
         {
           int is_tx_trunk = (msg_1 & 0x200000) >> 21;

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -685,7 +685,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             {
               state->edacs_lcn_count = state->edacs_cc_lcn;
             }
-            fprintf (stderr, " :: System ID [%04X] Control Channel LCN [%02d]%s", system, state->edacs_cc_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: System ID [%04X] CC LCN [%02d]%s", system, state->edacs_cc_lcn, get_lcn_status_string(lcn));
 
             //check for control channel lcn frequency if not provided in channel map or in the lcn list
             if (state->trunk_lcn_freq[state->edacs_cc_lcn-1] == 0)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -813,17 +813,16 @@ void edacs(dsd_opts * opts, dsd_state * state)
           int unk1    = (msg_1 & 0x70000) >> 20;   //unknown 3 bit value preceeding the SGID
           int sgid    = (msg_1 & 0xFFFF);          //patched supergroup ID
 
-          //Note: SSN is the supergroup sequence number in P25 Harris lingo, but you would think this would be kind of redundant
-          //since the SGID is itself a unique number as well (waste of bits), but guess that's how their systems work
-          //that being said, the SSN is always the same for each SGID, so those values seem to go together here as well
-          int ssn     = (msg_2 & 0xFF00000) >> 20; //this value seems to incrememnt based on SGID, so assigning 8-bit as the SSN
-          int unk2    = (msg_2 & 0xF0000) >> 16;   //unknown 4 bit value preceeding 20-bit target value of patch
-          int target  = (msg_2 & 0xFFFFF);         //target group or individual ID (20-bit) to include in supergroup
+          //Updated Observation: The 'SSN' value may not be unique in this instance, so may be an entirely different value
+          //altogether. Its function is still unknown, but for the sake of displaying patches, is not required.
 
-          fprintf (stderr, "%s", KWHT); //just make it stick out for now
-          fprintf (stderr, " System Dynamic Regroup :: SSN [%03d] SGID [%05d] Target [%07d]", ssn, sgid, target);
-          if (unk1) fprintf (stderr, " UNK1: [%X]", unk1); //this value seems to always be zero
-          if (unk2) fprintf (stderr, " UNK2: [%X]", unk2); //this value seems to always be zero
+          int ssn     = (msg_2 & 0xFF00000) >> 20; //this value seems to incrememnt based on SGID, so assigning 8-bit as the SSN
+          int target  = (msg_2 &   0xFFFFF);      //target group or individual ID (20-bit) to include in supergroup
+          
+          fprintf (stderr, "%s", KWHT);
+          fprintf (stderr, " System Dynamic Regroup :: SGID [%05d] Target [%07d]", sgid, target);
+          if (unk1) fprintf (stderr, " UNK1: [%01X]", unk1); //this value seems to always be zero
+          if (ssn)  fprintf (stderr, " UNK2: [%02X]", ssn); //this may or may not be a unique value to each SGID
           fprintf (stderr, "%s", KNRM);
         }
         //Serial Number Request (not seen in the wild, see US patent 20030190923, Figure 2b)

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -611,7 +611,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
           //and overwrite current values in the matrix
           state->lasttg  = 999999999;
           state->lastsrc = 999999999;
-          state->edacs_vc_call_type = EDACS_IS_TEST_CALL | EDACS_IS_VOICE; //manually set to trigger voice call in ncurses, but no other flags
+          state->edacs_vc_call_type = EDACS_IS_VOICE | EDACS_IS_TEST_CALL;
         }
         //Adjacent Sites
         else if (mt2 == 0x1)
@@ -990,7 +990,8 @@ void edacs(dsd_opts * opts, dsd_state * state)
         if (source != 0) state->lastsrc = source;
 
         //Call type for state
-                             state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
+        if (target == 0 && source == 0) state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_TEST_CALL;
+        else                            state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
         if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
         //Test calls are just I-Calls with source and target of 0
@@ -1006,7 +1007,6 @@ void edacs(dsd_opts * opts, dsd_state * state)
           //and overwrite current values in the matrix
           state->lasttg  = 999999999;
           state->lastsrc = 999999999;
-          state->edacs_vc_call_type = EDACS_IS_TEST_CALL | EDACS_IS_VOICE; //manually set to trigger voice call in ncurses, but no other flags
           lcn = 0; //set to zero here, because this is not an actual call, so don't tune to it
         }
         else
@@ -1643,7 +1643,6 @@ void edacs(dsd_opts * opts, dsd_state * state)
             //assign bogus values so that this will show up in ncurses terminal and overwrite current values in the matrix
             state->lasttg  = 999999999;
             state->lastsrc = 999999999;
-            state->edacs_vc_call_type = EDACS_IS_TEST_CALL | EDACS_IS_VOICE; //manually set to trigger voice call in ncurses, but no other flags
             lcn = 0; //set to zero here, because this is not an actual call, so don't tune to it
           }
           else {
@@ -1668,8 +1667,9 @@ void edacs(dsd_opts * opts, dsd_state * state)
                         state->lastsrc = source;
 
           //Call type for state
-                               state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
-          if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
+          if (target == 0 && source == 0) state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_TEST_CALL;
+          else                            state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
+          if (is_digital == 1)            state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
           char mode[8]; //allow, block, digital enc
           sprintf (mode, "%s", "");

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -981,7 +981,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
 
         }
       }
-      //I-Call Grant Update
+      //I-Call/Test Call Assignment/Update
       else if (mt1 == 0x10)
       {
         lcn = (msg_2 & 0x1F00000) >> 20;
@@ -1006,15 +1006,14 @@ void edacs(dsd_opts * opts, dsd_state * state)
                              state->edacs_vc_call_type  = EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL;
         if (is_digital == 1) state->edacs_vc_call_type |= EDACS_IS_DIGITAL;
 
+        //Test calls are just I-Calls with source and target of 0
         if (target == 0 && source == 0)
         {
           fprintf (stderr, "%s", KMAG);
-          //this seems to be the continuation of the Initiate Test Call Command
-          //normally, this appears as an "Analog I-Call", but with 0 tg and src,
-          //its possible that those values could still be present, and that all
-          //"Analog I-Call" is meant to be the assignment and update of the initiation
-          if (is_update) fprintf (stderr, " Test Call Update     :: LCN: %02d;", lcn);
-          else           fprintf (stderr, " Test Call Assignment :: LCN: %02d;", lcn);
+          fprintf (stderr, " Test Call");
+          if (is_update == 0) fprintf (stderr, " Assignment");
+          else                fprintf (stderr, " Update");
+          fprintf (stderr, " :: LCN [%02d]%s", lcn, get_lcn_status_string(lcn));
           state->edacs_vc_lcn = lcn;
           //assign bogus values so that this will show up in ncurses terminal
           //and overwrite current values in the matrix

--- a/src/edacs-fme.c
+++ b/src/edacs-fme.c
@@ -685,7 +685,7 @@ void edacs(dsd_opts * opts, dsd_state * state)
             {
               state->edacs_lcn_count = state->edacs_cc_lcn;
             }
-            fprintf (stderr, " :: System ID [%04X] Control Channel LCN [%d]%s", system, state->edacs_cc_lcn, get_lcn_status_string(lcn));
+            fprintf (stderr, " :: System ID [%04X] Control Channel LCN [%02d]%s", system, state->edacs_cc_lcn, get_lcn_status_string(lcn));
 
             //check for control channel lcn frequency if not provided in channel map or in the lcn list
             if (state->trunk_lcn_freq[state->edacs_cc_lcn-1] == 0)

--- a/src/m17.c
+++ b/src/m17.c
@@ -1897,13 +1897,13 @@ void encodeM17STR(dsd_opts * opts, dsd_state * state)
           voice2[i] = sample;
         }
       }
-
+      opts->rtl_rms = rtl_return_rms();
       #endif
     }
 
     //read in RMS value for vox function; NOTE: will not work correctly SOCAT STDIO TCP due to blocking when no samples to read
-    if (opts->audio_in_type == 3) opts->rtl_rms = rtl_return_rms();
-    else opts->rtl_rms = raw_rms(voice1, nsam, 1) / 2; //dividing by two so mic isn't so sensitive on vox
+    if (opts->audio_in_type != 3)
+      opts->rtl_rms = raw_rms(voice1, nsam, 1) / 2; //dividing by two so mic isn't so sensitive on vox
 
     //low pass filter
     if (opts->use_lpf == 1)


### PR DESCRIPTION
Mostly minor and cosmetic changes for visual (logging and ncurses) consistency across the board.

Fix an incorrect indexer `i` vs `j` in the ncurses matrix.