### PR TITLE
Fix OOB writes in ez.cpp HB/HBS vectors causing P25p2 TDMA voice segfault

### DIFF
--- a/src/ez.cpp
+++ b/src/ez.cpp
@@ -85,7 +85,7 @@ int ez_rs28_facch (int payload[156], int parity[114])
   int i, j, k, b;
 
   //init HB
-  for (i = 0; i < 64; i++)
+  for (i = 0; i < (int)HB.size(); i++)
   {
 	HB[i] = 0;
   }
@@ -136,7 +136,7 @@ int ez_rs28_sacch (int payload[180], int parity[132])
   int i, j, k, b;
 
   //init HBS
-  for (i = 0; i < 64; i++)
+  for (i = 0; i < (int)HBS.size(); i++)
   {
 	HBS[i] = 0;
   }


### PR DESCRIPTION
Closes https://github.com/lwvmobile/dsd-fme/issues/304

- Root cause: Out-of-bounds access in src/ez.cpp when initializing std::vector<uint8_t> HB(63) and HBS(63). The loops wrote 64 elements (0..63), violating operator[] assertion in libstdc++.
- Fix: Changed the init loops to iterate up to HB.size() and HBS.size() respectively to avoid OOB.
- Impact: Prevents segfault during P25 Phase 2 TDMA voice when FACCH/SACCH/ESS correction runs.