### PR TITLE
Fix NXDN CAC decoder temp buffer overflow in nxdn_deperm_cac causing segfaults under -O2/-O3

### DIFF
--- a/src/nxdn_deperm.c
+++ b/src/nxdn_deperm.c
@@ -1038,7 +1038,7 @@ void nxdn_deperm_cac(dsd_opts * opts, dsd_state * state, uint8_t bits[300])
 	}
 
 	//switch to the convolutional decoder
-	uint8_t temp[179];
+	uint8_t temp[350];
 	uint8_t s0;
   uint8_t s1;
 	uint8_t m_data[22]; //26


### PR DESCRIPTION
Closes https://github.com/lwvmobile/dsd-fme/issues/305

- Root cause: Stack buffer overflow in nxdn_deperm_cac: wrote 350 bytes into temp[179], corrupting nearby data under optimization.
- Fix: Resize temp to 350 (matching depunctured length) before decode.
- Impact: Removes undefined behavior; fixes segfaults in optimized builds (-O2/-O3/-fexceptions) during NXDN48 CAC decoding; no behavior change otherwise.