### PR TITLE
Silence unused variable warning on ARM 32bit compilation

### DIFF
--- a/src/rtl_sdr_fm.cpp
+++ b/src/rtl_sdr_fm.cpp
@@ -580,6 +580,9 @@ static void dsd_fme_init_runtime_dispatch_once(void)
 #endif
     use_neon = (hw & HWCAP_NEON) ? 1 : 0;
 #endif
+#if !defined(__ARM_NEON) && !defined(__ARM_NEON__)
+    (void)use_neon;
+#endif
 #endif
 
     /* Fallbacks */


### PR DESCRIPTION
Added a conditional `(void)use_neon;` in the 32-bit ARM path to silence the unused variable when NEON intrinsics aren’t compiled in.