### PR TITLE
macOS: disable OSS backend cleanly and fix build/link errors

### DIFF
--- a/include/dsd.h
+++ b/include/dsd.h
@@ -59,8 +59,9 @@
 #include "p25p1_heuristics.h"
 
 //OSS support
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/soundcard.h>
-
+#endif
 #include <pulse/pulseaudio.h> //PULSE AUDIO
 #include <pulse/simple.h>     //PULSE AUDIO
 #include <pulse/error.h>      //PULSE AUDIO

--- a/src/dsd_audio.c
+++ b/src/dsd_audio.c
@@ -189,6 +189,14 @@ void parse_pulse_output_string (dsd_opts * opts, char * input)
   }
 }
 
+#ifdef __APPLE__
+// macOS does not support OSS (/dev/dsp).
+// Provide a stub so callers can link while using Pulse/CoreAudio backends.
+void openOSSOutput(dsd_opts *opts)
+{
+  (void)opts;
+}
+#else
 void openOSSOutput (dsd_opts * opts)
 {
   int fmt;
@@ -207,6 +215,7 @@ void openOSSOutput (dsd_opts * opts)
         exit(1);
       }
 
+      
       fmt = 0;
       if (ioctl (opts->audio_out_fd, SNDCTL_DSP_RESET) < 0)
       {
@@ -303,6 +312,7 @@ void openOSSOutput (dsd_opts * opts)
     }
   }
 }
+#endif
 
 void
 processAudio (dsd_opts * opts, dsd_state * state)

--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -3392,18 +3392,23 @@
      //to a variable config, it cannot be the input as well
  
  
+     #ifndef __APPLE__
      if((strncmp(opts.audio_in_dev, "/dev/audio", 10) == 0))
      {
        sprintf (opts.audio_in_dev, "%s", "/dev/dsp");
        fprintf (stderr, "Switching to /dev/dsp.\n");
      }
- 
+     #endif
+
+     #ifndef __APPLE__ 
      if((strncmp(opts.audio_in_dev, "pa", 2) == 0))
      {
        sprintf (opts.audio_in_dev, "%s", "/dev/dsp");
        fprintf (stderr, "Switching to /dev/dsp.\n");
      }
- 
+     #endif
+
+     #ifndef __APPLE__
      speed = 48000; //hardset to 48000
      if((strncmp(opts.audio_in_dev, "/dev/dsp", 8) == 0))
      {
@@ -3437,24 +3442,31 @@
  
        opts.audio_in_type = 5; //5 will become OSS input type
      }
+     #endif
  
      //check for OSS output
+     #ifndef __APPLE__
      if((strncmp(opts.audio_out_dev, "/dev/audio", 10) == 0))
      {
        sprintf (opts.audio_out_dev, "%s", "/dev/dsp");
        fprintf (stderr, "Switching to /dev/dsp.\n");
      }
+     #endif
  
+     #ifndef __APPLE__
      if((strncmp(opts.audio_out_dev, "pa", 2) == 0))
      {
        sprintf (opts.audio_out_dev, "%s", "/dev/dsp");
        fprintf (stderr, "Switching to /dev/dsp.\n");
      }
+     #endif
  
      //this will only open OSS output if its listed as a type
      //changed to this so I could call it freely inside of ncurses terminal
+     #ifndef __APPLE__
      if (opts.playfiles == 0)
       openOSSOutput(&opts);
+     #endif
  
      if (opts.playfiles == 1)
      {
@@ -3466,8 +3478,10 @@
        opts.pulse_digi_out_channels = 1;
        if (opts.audio_out_type == 0)
         openPulseOutput(&opts);
+       #ifndef __APPLE__
        else if((strncmp(opts.audio_out_dev, "/dev/dsp", 8) == 0))
         openOSSOutput(&opts); //open after split == 1 so it will open and playback at the proper speed
+       #endif
      }
  
      //this particular if-elseif-else could be rewritten to be a lot neater and simpler

--- a/src/dsd_ncurses_menu.c
+++ b/src/dsd_ncurses_menu.c
@@ -130,11 +130,13 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     closePulseOutput (opts);
   }
 
+  #ifndef __APPLE__
   //close OSS output
   if (opts->audio_out_type == 2 || opts->audio_out_type == 5)
   {
     close (opts->audio_out_fd);
   }
+  #endif
 
   if (opts->audio_in_type == 0) //close pulse input if it is the specified input method
   {
@@ -1585,10 +1587,12 @@ void ncursesMenu (dsd_opts * opts, dsd_state * state)
     openPulseOutput (opts);
   }
 
+  #ifndef __APPLE__
   if (opts->audio_out_type == 2 || opts->audio_out_type == 5)
   {
     openOSSOutput (opts);
   }
+  #endif
 
 
   if (opts->audio_in_type == 0) //reopen pulse input if it is the specified input method


### PR DESCRIPTION
macOS has no OSS (/dev/dsp) support, but dsd-fme currently compiles and links OSS code unconditionally, leading to build and link failures.

This PR:

* disables OSS backend cleanly on macOS

* provides a no-op openOSSOutput() stub to satisfy callers

* guards OSS-specific headers and ioctl usage

* preserves existing behavior on Linux/OSS platforms

This allows dsd-fme to build and run correctly on macOS using PulseAudio/CoreAudio paths.