### PR TITLE
Fix -r option argument order dependency

### DIFF
--- a/src/dsd_main.c
+++ b/src/dsd_main.c
@@ -3088,7 +3088,6 @@
            opts.dmr_stereo = 0;
            state.dmr_stereo = 0;
            sprintf (opts.output_name, "MBE Playback");
-           state.optind = optind;
            break;
          case 'l':
            opts.use_cosine_filter = 0;
@@ -3098,6 +3097,10 @@
            exit (0);
          }
      }
+
+     // Set optind after getopt completes so -r works regardless of argument order
+     if (opts.playfiles == 1)
+       state.optind = optind;
  
      if (opts.resume > 0)
      {


### PR DESCRIPTION
Move state.optind assignment from inside case 'r' to after the getopt loop completes. This ensures optind points to the first positional argument regardless of option order.

Before: -r file.amb -w output.wav would fail with "could not open -w"
After: argument order no longer matters for -r with other options